### PR TITLE
fix client loop

### DIFF
--- a/client/tmclient/client.py
+++ b/client/tmclient/client.py
@@ -25,7 +25,7 @@ class Client:
 
     def run(self):
         asyncio.wait_for(asyncio.ensure_future(self.connect(), loop=self.loop),60.0, loop=self.loop)
-        self.loop.run()
+        self.ui.loop.run()
 
     def show_menu(self):
         self.ui.base = MainMenu(self.loop, client=self)


### PR DESCRIPTION
The current master crashes like this when you run the client:

> `Traceback (most recent call last):
>   File "/home/hvincent/repos/tildemush/venv/bin/tmclient", line 11, in <module>
>       load_entry_point('tildemush-client', 'console_scripts', 'tmclient')()
>   File "/home/hvincent/repos/tildemush/client/tmclient/__init__.py", line 8, in main
>       client.run()
>   File "/home/hvincent/repos/tildemush/client/tmclient/client.py", line 28, in run
>       self.loop.run()
> AttributeError: '_UnixSelectorEventLoop' object has no attribute 'run'`

This PR corrects the loop call in client.py so the client starts correctly.