### PR TITLE
UI draft

### DIFF
--- a/client/tmclient/screens.py
+++ b/client/tmclient/screens.py
@@ -206,6 +206,7 @@ class GameMain(urwid.Frame):
             self.handle_game_input(self.prompt.get_edit_text())
         else:
             self.prompt.keypress((size[0],), key)
+            self.handle_keypress(key)
 
     def handle_game_input(self, text):
         # TODO handle any validation of text
@@ -221,6 +222,15 @@ class GameMain(urwid.Frame):
 
         asyncio.ensure_future(self.client_state.send(server_msg), loop=self.loop)
         self.prompt.edit_text = ''
+
+    def handle_keypress(self, key):
+        # debugging output
+        self.footer = urwid.Text(key)
+
+        if key == 'f12':
+            # TODO: this isn't getting caught by the server for some reason
+            asyncio.ensure_future(self.client_state.send('COMMAND QUIT'), loop=self.loop)
+            quit_client('')
 
     def here_info(self):
         room_name = self.room.get("name")

--- a/client/tmclient/screens.py
+++ b/client/tmclient/screens.py
@@ -107,24 +107,6 @@ class GamePrompt(urwid.Edit):
     def __init__(self):
         super().__init__(caption='> ', multiline=True)
 
-class DashedBox(urwid.LineBox):
-    def __init__(self, box_item):
-        super().__init__(box_item,
-                tlcorner='┌', tline='╌', lline='╎', trcorner='┐', blcorner='└',
-                rline='╎', bline='╌', brcorner='┘'
-                )
-
-class TabHeader(urwid.LineBox):
-    def __init__(self, contents, position=""):
-        if position == 'first':
-            super().__init__(contents, tlcorner='╭', trcorner='╮',
-                    bline=' ', blcorner='│', brcorner='└')
-        elif position == 'last':
-            super().__init__(contents, tlcorner='╭', trcorner='╮',
-                    blcorner='┴', brcorner='┤')
-        else:
-            super().__init__(contents, tlcorner='╭', trcorner='╮',
-                    blcorner='┴', brcorner='┴')
 
 class GameMain(urwid.Frame):
     def __init__(self, client_state, loop):
@@ -134,11 +116,12 @@ class GameMain(urwid.Frame):
         self.room = {}
         self.user = {}
         self.tab_headers = [
-                    TabHeader(urwid.Text("F1 MAIN"), position='first'),
-                    TabHeader(urwid.Text("F2 WITCH")),
-                    TabHeader(urwid.Text("F3 WORLDMAP")),
-                    TabHeader(urwid.Text("F4 SETTINGS")),
-                    TabHeader(urwid.Text("F12 QUIT"), position='last')
+                    ui.TabHeader(urwid.Text("F1 MAIN"), position='first',
+                        selected=True),
+                    ui.TabHeader(urwid.Text("F2 WITCH")),
+                    ui.TabHeader(urwid.Text("F3 WORLDMAP")),
+                    ui.TabHeader(urwid.Text("F4 SETTINGS")),
+                    ui.TabHeader(urwid.Text("F12 QUIT"), position='last')
                 ]
 
         self.header = urwid.Columns(self.tab_headers)
@@ -154,9 +137,9 @@ class GameMain(urwid.Frame):
         self.world_body = urwid.Columns([
             self.game_text,
             urwid.Pile([
-                DashedBox(urwid.Filler(self.here_text, valign='top')),
-                DashedBox(urwid.Filler(self.minimap_text, valign='top')),
-                DashedBox(urwid.Filler(self.user_text, valign='top'))
+                ui.DashedBox(urwid.Filler(self.here_text, valign='top')),
+                ui.DashedBox(urwid.Filler(self.minimap_text, valign='top')),
+                ui.DashedBox(urwid.Filler(self.user_text, valign='top'))
             ])
         ])
 

--- a/client/tmclient/screens.py
+++ b/client/tmclient/screens.py
@@ -112,20 +112,22 @@ class GameMain(urwid.Frame):
         self.client_state = client_state
         self.loop = loop
         # TODO: get room and user info passed in on init?
-        self.room_info = {}
-        self.user_info = {}
+        self.room = {}
+        self.user = {}
         self.banner = urwid.Text('====welcome 2 tildemush, u are jacked in====')
         self.game_text = urwid.Pile([urwid.Text('you have reconstitued as {desc} in {location}'.format(
-                desc=self.user_info.get("description"),
-                location=self.room_info.get("name")
+                desc=self.user.get("description"),
+                location=self.room.get("name")
                 ))])
-        self.here_text = urwid.Pile([urwid.Text('{}'.format(self.here_info()))])
+        self.here_text = urwid.Pile([urwid.Text(self.here_info())])
+        self.user_text = urwid.Pile([urwid.Text(self.user_info())])
         columns = urwid.Columns([
             urwid.Filler(self.game_text, valign='top'),
             urwid.Pile([
                 urwid.LineBox(urwid.Filler(self.here_text, valign='top')),
                 urwid.LineBox(urwid.Filler(urwid.Text('MAP'), valign='top')),
-                urwid.LineBox(urwid.Filler(urwid.Text('character info'), valign='top'))
+                urwid.LineBox(urwid.Filler(self.user_text, valign='top'))
+                #urwid.LineBox(urwid.Filler(urwid.Text('character info'), valign='top'))
             ])
         ], dividechars=1)
         self.main = urwid.Pile([columns])
@@ -144,6 +146,11 @@ class GameMain(urwid.Frame):
             self.here_text.contents.clear()
             self.here_text.contents.append(
                 (urwid.Text(text), self.here_text.options()))
+        elif server_msg.startswith('info'):
+            text = ' '.join(server_msg.split(' ')[1:])
+            self.user_text.contents.clear()
+            self.user_text.contents.append(
+                (urwid.Text(text), self.user_text.options()))
         else:
             self.game_text.contents.append(
                 (urwid.Text(server_msg), self.game_text.options()))
@@ -174,7 +181,15 @@ class GameMain(urwid.Frame):
         self.prompt.edit_text = ''
 
     def here_info(self):
-        room_name = self.room_info.get("name")
+        room_name = self.room.get("name")
         info = "[{}]".format(room_name)
+
+        return info
+    
+    def user_info(self):
+        info = '<a {desc} named {name}>'.format(
+                desc=self.user.get("description"),
+                name=self.user.get("name")
+                )
 
         return info

--- a/client/tmclient/screens.py
+++ b/client/tmclient/screens.py
@@ -127,7 +127,6 @@ class GameMain(urwid.Frame):
                 urwid.LineBox(urwid.Filler(self.here_text, valign='top')),
                 urwid.LineBox(urwid.Filler(urwid.Text('MAP'), valign='top')),
                 urwid.LineBox(urwid.Filler(self.user_text, valign='top'))
-                #urwid.LineBox(urwid.Filler(urwid.Text('character info'), valign='top'))
             ])
         ], dividechars=1)
         self.main = urwid.Pile([columns])

--- a/client/tmclient/screens.py
+++ b/client/tmclient/screens.py
@@ -27,7 +27,9 @@ class Splash(Screen):
 class MainMenu(Screen):
     def __init__(self, loop, client=None, exit=lambda _: True):
         self.loop = loop
-        self.base = ui.solidfill('░', 'background')
+        ftr = urwid.Text('press ESC to close windows', align='center')
+        body = ui.solidfill('░', 'background')
+        self.base = urwid.Frame(body=body, footer=ftr)
         super().__init__(self.base, client, exit)
         self.show_menu()
 
@@ -56,7 +58,7 @@ class MainMenu(Screen):
         else:
             un_field = FormField(caption='username: ', name='username')
             pw_field = FormField(caption='password: ', name='password', mask='~')
-            submit_btn = urwid.Button('login!')
+            submit_btn = urwid.Button('login! >')
             login_form = Form([un_field, pw_field], submit_btn)
 
             def wait_for_login(_):
@@ -72,6 +74,7 @@ class MainMenu(Screen):
         await self.client.authenticate(login_data['username'], login_data['password'])
 
     def show_register(self):
+        info = urwid.Text('register a new account! password must be at least 12 characters long.\n')
         un_field = FormField(caption='username: ', name='username')
         pw_field = FormField(caption='password: ', name='password', mask='~')
         pw_confirm_field = FormField(caption='confirm password: ', name='confirm_password', mask='~')
@@ -84,7 +87,7 @@ class MainMenu(Screen):
                 60.0, loop=self.loop)
 
         urwid.connect_signal(submit_btn, 'click', wait_for_register)
-        self.open_box(urwid.Filler(register_form))
+        self.open_box(urwid.Filler(urwid.Pile([info, register_form])))
 
     async def handle_register(self, register_data):
         if not register_data['username']:

--- a/client/tmclient/screens.py
+++ b/client/tmclient/screens.py
@@ -124,7 +124,7 @@ class GameMain(urwid.Frame):
         self.here_text = urwid.Pile([urwid.Text(self.here_info())])
         self.user_text = urwid.Pile([urwid.Text(self.user_info())])
         self.minimap_text = urwid.Pile([urwid.Text("MAP")])
-        self.world_body = urwid.Columns([
+        self.main_body = urwid.Columns([
             self.game_text,
             urwid.Pile([
                 ui.DashedBox(urwid.Filler(self.here_text, valign='top')),
@@ -132,14 +132,13 @@ class GameMain(urwid.Frame):
                 ui.DashedBox(urwid.Filler(self.user_text, valign='top'))
             ])
         ])
+        self.main_banner = urwid.Text('====welcome 2 tildemush, u are jacked in====')
+        self.main_prompt = GamePrompt()
+        self.main_view = urwid.Frame(header=self.main_banner,
+                body=self.main_body, footer=self.main_prompt)
+        self.main_view.focus_position = 'footer'
 
-        self.world_banner = urwid.Text('====welcome 2 tildemush, u are jacked in====')
-        self.world_prompt = GamePrompt()
-        self.world_view = urwid.Frame(header=self.world_banner,
-                body=self.world_body, footer=self.world_prompt)
-        self.world_view.focus_position = 'footer'
-
-        self.main_tab = ui.GameTab(self.world_view,
+        self.main_tab = ui.GameTab(self.main_view,
                 ui.TabHeader("F1 MAIN", position='first',
                     selected=True))
 
@@ -159,7 +158,7 @@ class GameMain(urwid.Frame):
                 ui.TabHeader("F4 SETTINGS"))
 
         # quit placeholder
-        self.quit_view = self.world_view
+        self.quit_view = self.main_view
         self.quit_tab = ui.GameTab(self.quit_view,
                 ui.TabHeader("F9 QUIT", position='last'))
 
@@ -174,7 +173,7 @@ class GameMain(urwid.Frame):
         self.tab_headers = urwid.Columns([])
         self.header = self.tab_headers
         self.refresh_tabs()
-        self.prompt = self.world_prompt
+        self.prompt = self.main_prompt
         self.main = self.main_tab
         self.statusbar = urwid.Text("connection okay!", align='right')
         self.client_state.set_on_recv(self.on_server_message)
@@ -205,7 +204,7 @@ class GameMain(urwid.Frame):
 
     def focus_prompt(self):
         self.focus_position = 'body'
-        self.world_view.focus_position = 'footer'
+        self.main_view.focus_position = 'footer'
 
     def keypress(self, size, key):
         if key == 'enter':
@@ -245,11 +244,9 @@ class GameMain(urwid.Frame):
             self.refresh_tabs()
 
     def refresh_tabs(self):
-        self.tab_headers.contents.clear()
         headers = []
         for tab in sorted(self.tabs.keys()):
             headers.append(self.tabs.get(tab).tab_header)
-
         self.tab_headers = urwid.Columns(headers)
         self.header = self.tab_headers
 

--- a/client/tmclient/screens.py
+++ b/client/tmclient/screens.py
@@ -188,16 +188,11 @@ class GameMain(urwid.Frame):
             pass
         elif server_msg.startswith('here'):
             # TODO: this is kind of filler for now for updating the here
-            # panel; consider better data format
+            # panel; will need to be updated when DATA payload is implemented
             text = ' '.join(server_msg.split(' ')[1:])
             self.here_text.contents.clear()
-            self.here_text.contents.append(
-                (urwid.Text(text), self.here_text.options()))
-        elif server_msg.startswith('info'):
-            text = ' '.join(server_msg.split(' ')[1:])
-            self.user_text.contents.clear()
-            self.user_text.contents.append(
-                (urwid.Text(text), self.user_text.options()))
+            self.here_text.contents.append(urwid.Text(text),
+                    self.here_text.options())
         else:
             new_line = urwid.Text(server_msg)
             self.game_walker.append(new_line)
@@ -239,7 +234,8 @@ class GameMain(urwid.Frame):
         self.footer = urwid.Text(key)
 
         if key == 'f9':
-            # TODO: this isn't getting caught by the server for some reason
+            # TODO: quit command isn't getting caught by the server for some
+            # reason?
             asyncio.ensure_future(self.client_state.send('COMMAND QUIT'), loop=self.loop)
             quit_client('')
         elif key in self.tabs.keys():

--- a/client/tmclient/screens.py
+++ b/client/tmclient/screens.py
@@ -114,7 +114,7 @@ class DashedBox(urwid.LineBox):
                 rline='╎', bline='╌', brcorner='┘'
                 )
 
-class GameTab(urwid.LineBox):
+class TabHeader(urwid.LineBox):
     def __init__(self, contents, position=""):
         if position == 'first':
             super().__init__(contents, tlcorner='╭', trcorner='╮',
@@ -135,30 +135,34 @@ class GameMain(urwid.Frame):
         self.user = {}
         self.banner = urwid.Text('====welcome 2 tildemush, u are jacked in====')
         self.tabs = [
-                    GameTab(urwid.Text("F1 MAIN"), position='first'),
-                    GameTab(urwid.Text("F2 WITCH")),
-                    GameTab(urwid.Text("F3 WORLDMAP")),
-                    GameTab(urwid.Text("F4 SETTINGS")),
-                    GameTab(urwid.Text("F12 QUIT"), position='last')
+                    TabHeader(urwid.Text("F1 MAIN"), position='first'),
+                    TabHeader(urwid.Text("F2 WITCH")),
+                    TabHeader(urwid.Text("F3 WORLDMAP")),
+                    TabHeader(urwid.Text("F4 SETTINGS")),
+                    TabHeader(urwid.Text("F12 QUIT"), position='last')
                 ]
 
         self.header = urwid.Columns(self.tabs)
 
         # game view stuff
-        self.game_text = urwid.Pile([urwid.Text('you have reconstitued as {desc} in {location}'.format(
+        self.game_text = urwid.Pile([
+            urwid.Text('you have reconstitued as {desc} in {location}'.format(
                 desc=self.user.get("description"),
                 location=self.room.get("name")
-                ))])
-        self.here_text = urwid.Pile([urwid.Text(self.here_info())])
-        self.user_text = urwid.Pile([urwid.Text(self.user_info())])
+                ))
+            ])
+        self.here_text = urwid.Text(self.here_info())
+        self.user_text = urwid.Text(self.user_info())
+        self.minimap_text = urwid.Text("MAP")
         self.world_body = urwid.LineBox(urwid.Columns([
             urwid.Filler(self.game_text, valign='top'),
             urwid.Pile([
                 DashedBox(urwid.Filler(self.here_text, valign='top')),
-                urwid.LineBox(urwid.Filler(urwid.Text('MAP'), valign='top')),
-                urwid.LineBox(urwid.Filler(self.user_text, valign='top'))
+                DashedBox(urwid.Filler(self.minimap_text, valign='top')),
+                DashedBox(urwid.Filler(self.user_text, valign='top'))
             ])
-        ], dividechars=1), tlcorner='│', trcorner='│', tline='')
+        ]), tlcorner='│', trcorner='│', tline='')
+
         self.world_prompt = GamePrompt()
         self.world_banner = urwid.Text("WORLD VIEW")
 

--- a/client/tmclient/screens.py
+++ b/client/tmclient/screens.py
@@ -231,7 +231,7 @@ class GameMain(urwid.Frame):
 
     def handle_keypress(self, key):
         # debugging output
-        self.footer = urwid.Text(key)
+        #self.footer = urwid.Text(key)
 
         if key == 'f9':
             # TODO: quit command isn't getting caught by the server for some

--- a/client/tmclient/screens.py
+++ b/client/tmclient/screens.py
@@ -150,13 +150,26 @@ class GameMain(urwid.Frame):
         self.world_view.focus_position = 'footer'
 
         self.main_tab = ui.GameTab(self.world_view, self.tab_headers[0], "MAIN")
-        #self.world_view_wrapper = urwid.LineBox(self.world_view, tlcorner='│', trcorner='│', tline='')
 
+        # witch view stuff
         self.witch_view = urwid.Filler(urwid.Text("witch editor in progress", align='center'), valign='middle')
-
         self.witch_tab = ui.GameTab(self.witch_view, self.tab_headers[1], "WITCH")
 
-        self.tabs = {"f1": self.main_tab, "f2": self.witch_tab}
+        # worldmap view stuff
+        self.worldmap_view = urwid.Filler(urwid.Text("worldmap coming soon", align='center'), valign='middle')
+        self.worldmap_tab = ui.GameTab(self.worldmap_view, self.tab_headers[2],
+                "WORLDMAP")
+
+        # settings view stuff
+        self.settings_view = urwid.Filler(urwid.Text("settings menu under construction", align='center'), valign='middle')
+        self.settings_tab = ui.GameTab(self.settings_view, self.tab_headers[3],
+                "SETTINGS")
+
+        self.tabs = {
+                "f1": self.main_tab,
+                "f2": self.witch_tab,
+                "f3": self.worldmap_tab,
+                "f4": self.settings_tab}
 
         # set starting conditions
         self.prompt = self.world_prompt
@@ -224,7 +237,18 @@ class GameMain(urwid.Frame):
             asyncio.ensure_future(self.client_state.send('COMMAND QUIT'), loop=self.loop)
             quit_client('')
         elif key in self.tabs.keys():
+            # tab switcher
+            self.body.unfocus()
             self.body = self.tabs.get(key)
+            self.body.focus()
+            self.refresh_tabs()
+
+    def refresh_tabs(self):
+        self.tab_headers.clear()
+        for tab in sorted(self.tabs.keys()):
+            self.tab_headers.append(self.tabs.get(tab).tab)
+        self.header = urwid.Columns(self.tab_headers)
+
 
     def here_info(self):
         room_name = self.room.get("name")

--- a/client/tmclient/screens.py
+++ b/client/tmclient/screens.py
@@ -114,12 +114,12 @@ class GameMain(urwid.Frame):
         # TODO: get room and user info passed in on init?
         self.room_info = {}
         self.user_info = {}
-        self.banner = urwid.Text('welcome 2 tildemush, u are jacked in')
-        self.game_text = urwid.Pile([urwid.Text('you are reconstitued as {desc} in {location}'.format(
+        self.banner = urwid.Text('====welcome 2 tildemush, u are jacked in====')
+        self.game_text = urwid.Pile([urwid.Text('you have reconstitued as {desc} in {location}'.format(
                 desc=self.user_info.get("description"),
                 location=self.room_info.get("name")
                 ))])
-        self.here_text = urwid.Pile([urwid.Text('YOU ARE HERE'), urwid.Text('{}'.format(self.here_info()))])
+        self.here_text = urwid.Pile([urwid.Text('{}'.format(self.here_info()))])
         columns = urwid.Columns([
             urwid.Filler(self.game_text, valign='top'),
             urwid.Pile([
@@ -137,11 +137,11 @@ class GameMain(urwid.Frame):
     async def on_server_message(self, server_msg):
         if server_msg == 'COMMAND OK':
             pass
-        elif server_msg.startswith('meta'):
+        elif server_msg.startswith('here'):
             # TODO: this is kind of filler for now for updating the here
             # panel; consider better data format
             text = ' '.join(server_msg.split(' ')[1:])
-            self.here_text.contents.pop()
+            self.here_text.contents.clear()
             self.here_text.contents.append(
                 (urwid.Text(text), self.here_text.options()))
         else:
@@ -175,6 +175,6 @@ class GameMain(urwid.Frame):
 
     def here_info(self):
         room_name = self.room_info.get("name")
-        info = "Current location: {}".format(room_name)
+        info = "[{}]".format(room_name)
 
         return info

--- a/client/tmclient/screens.py
+++ b/client/tmclient/screens.py
@@ -107,6 +107,25 @@ class GamePrompt(urwid.Edit):
     def __init__(self):
         super().__init__(caption='> ', multiline=True)
 
+class DashedBox(urwid.LineBox):
+    def __init__(self, box_item):
+        super().__init__(box_item,
+                tlcorner='┌', tline='╌', lline='╎', trcorner='┐', blcorner='└',
+                rline='╎', bline='╌', brcorner='┘'
+                )
+
+class GameTab(urwid.LineBox):
+    def __init__(self, contents, position=""):
+        if position == 'first':
+            super().__init__(contents, tlcorner='╭', trcorner='╮',
+                    bline=' ', blcorner='│', brcorner='└')
+        elif position == 'last':
+            super().__init__(contents, tlcorner='╭', trcorner='╮',
+                    blcorner='┴', brcorner='┤')
+        else:
+            super().__init__(contents, tlcorner='╭', trcorner='╮',
+                    blcorner='┴', brcorner='┴')
+
 class GameMain(urwid.Frame):
     def __init__(self, client_state, loop):
         self.client_state = client_state
@@ -115,20 +134,15 @@ class GameMain(urwid.Frame):
         self.room = {}
         self.user = {}
         self.banner = urwid.Text('====welcome 2 tildemush, u are jacked in====')
+        self.tabs = [
+                    GameTab(urwid.Text("F1 MAIN"), position='first'),
+                    GameTab(urwid.Text("F2 WITCH")),
+                    GameTab(urwid.Text("F3 WORLDMAP")),
+                    GameTab(urwid.Text("F4 SETTINGS")),
+                    GameTab(urwid.Text("F12 QUIT"), position='last')
+                ]
 
-        # TODO: un-hardcode tab appearances
-        self.header = urwid.Columns([
-                    urwid.LineBox(urwid.Text("F1 MAIN"), bline='.', blcorner='│',
-                        brcorner='└'),
-                    urwid.LineBox(urwid.Text("F2 WITCH"), brcorner='┴',
-                        blcorner='┴'),
-                    urwid.LineBox(urwid.Text("F3 WORLDMAP"), blcorner='┴',
-                        brcorner='┴'),
-                    urwid.LineBox(urwid.Text("F4 SETTINGS"), blcorner='┴',
-                        brcorner='┴'),
-                    urwid.LineBox(urwid.Text("F12 QUIT"), blcorner='┴',
-                        brcorner='┤')
-                    ])
+        self.header = urwid.Columns(self.tabs)
 
         # game view stuff
         self.game_text = urwid.Pile([urwid.Text('you have reconstitued as {desc} in {location}'.format(
@@ -140,7 +154,7 @@ class GameMain(urwid.Frame):
         self.world_body = urwid.LineBox(urwid.Columns([
             urwid.Filler(self.game_text, valign='top'),
             urwid.Pile([
-                urwid.LineBox(urwid.Filler(self.here_text, valign='top')),
+                DashedBox(urwid.Filler(self.here_text, valign='top')),
                 urwid.LineBox(urwid.Filler(urwid.Text('MAP'), valign='top')),
                 urwid.LineBox(urwid.Filler(self.user_text, valign='top'))
             ])

--- a/client/tmclient/screens.py
+++ b/client/tmclient/screens.py
@@ -113,14 +113,15 @@ class GameMain(urwid.Frame):
         self.loop = loop
         self.banner = urwid.Text('welcome 2 tildemush, u are jacked in')
         self.game_text = urwid.Pile([urwid.Text('lol game stuff happens here')])
-        self.main = urwid.Columns([
+        columns = urwid.Columns([
             urwid.Filler(self.game_text),
             urwid.Pile([
-                urwid.Filler(urwid.Text('details about your current room')),
-                urwid.Filler(urwid.Text('i donno a map?')),
-                urwid.Filler(urwid.Text('character info'))
+                urwid.LineBox(urwid.Filler(urwid.Text('YOU ARE HERE\n(room name) (population) (etc)'), valign='top')),
+                urwid.LineBox(urwid.Filler(urwid.Text('MAP'), valign='top')),
+                urwid.LineBox(urwid.Filler(urwid.Text('character info'), valign='top'))
             ])
         ], dividechars=1)
+        self.main = urwid.Pile([columns])
         self.prompt = GamePrompt()
         self.client_state.set_on_recv(self.on_server_message)
         super().__init__(header=self.banner, body=self.main, footer=self.prompt)

--- a/client/tmclient/screens.py
+++ b/client/tmclient/screens.py
@@ -140,27 +140,31 @@ class GameMain(urwid.Frame):
 
         self.main_tab = ui.GameTab(self.main_view,
                 ui.TabHeader("F1 MAIN", position='first',
-                    selected=True))
+                    selected=True), self.main_prompt)
 
         # witch view stuff
-        self.witch_view = urwid.Filler(urwid.Text("witch editor in progress", align='center'), valign='middle')
+        self.witch_prompt = urwid.Edit()
+        self.witch_view= urwid.Filler(urwid.Text("witch editor in progress", align='center'), valign='middle')
         self.witch_tab = ui.GameTab(self.witch_view,
-                ui.TabHeader("F2 WITCH"))
+                ui.TabHeader("F2 WITCH"), self.witch_prompt)
 
         # worldmap view stuff
+        self.worldmap_prompt = urwid.Edit()
         self.worldmap_view = urwid.Filler(urwid.Text("worldmap coming soon", align='center'), valign='middle')
         self.worldmap_tab = ui.GameTab(self.worldmap_view,
-                ui.TabHeader("F3 WORLDMAP"))
+                ui.TabHeader("F3 WORLDMAP"), self.worldmap_prompt)
 
         # settings view stuff
+        self.settings_prompt = urwid.Edit()
         self.settings_view = urwid.Filler(urwid.Text("settings menu under construction", align='center'), valign='middle')
         self.settings_tab = ui.GameTab(self.settings_view,
-                ui.TabHeader("F4 SETTINGS"))
+                ui.TabHeader("F4 SETTINGS"), self.settings_prompt)
 
         # quit placeholder
+        self.quit_prompt = urwid.Edit()
         self.quit_view = self.main_view
         self.quit_tab = ui.GameTab(self.quit_view,
-                ui.TabHeader("F9 QUIT", position='last'))
+                ui.TabHeader("F9 QUIT", position='last'), self.quit_prompt)
 
         # set starting conditions
         self.tabs = {
@@ -174,10 +178,9 @@ class GameMain(urwid.Frame):
         self.header = self.tab_headers
         self.refresh_tabs()
         self.prompt = self.main_prompt
-        self.main = self.main_tab
         self.statusbar = urwid.Text("connection okay!", align='right')
         self.client_state.set_on_recv(self.on_server_message)
-        super().__init__(header=self.header, body=self.main, footer=self.statusbar)
+        super().__init__(header=self.header, body=self.main_tab, footer=self.statusbar)
         self.focus_prompt()
 
     async def on_server_message(self, server_msg):
@@ -204,11 +207,14 @@ class GameMain(urwid.Frame):
 
     def focus_prompt(self):
         self.focus_position = 'body'
-        self.main_view.focus_position = 'footer'
+        self.prompt = self.body.prompt
 
     def keypress(self, size, key):
         if key == 'enter':
-            self.handle_game_input(self.prompt.get_edit_text())
+            if self.prompt == self.main_tab.prompt:
+                self.handle_game_input(self.prompt.get_edit_text())
+            else:
+                self.prompt.edit_text = ''
         else:
             self.prompt.keypress((size[0],), key)
             self.handle_keypress(key)
@@ -241,6 +247,7 @@ class GameMain(urwid.Frame):
             self.body.unfocus()
             self.body = self.tabs.get(key)
             self.body.focus()
+            self.focus_prompt()
             self.refresh_tabs()
 
     def refresh_tabs(self):

--- a/client/tmclient/screens.py
+++ b/client/tmclient/screens.py
@@ -148,11 +148,20 @@ class GameMain(urwid.Frame):
         self.world_view = urwid.Frame(header=self.world_banner,
                 body=self.world_body, footer=self.world_prompt)
         self.world_view.focus_position = 'footer'
-        self.world_view_wrapper = urwid.LineBox(self.world_view, tlcorner='│', trcorner='│', tline='')
+
+        self.main_tab = ui.GameTab(self.world_view, self.tab_headers[0], "MAIN")
+        #self.world_view_wrapper = urwid.LineBox(self.world_view, tlcorner='│', trcorner='│', tline='')
+
+        self.witch_view = urwid.Filler(urwid.Text("witch editor in progress", align='center'), valign='middle')
+
+        self.witch_tab = ui.GameTab(self.witch_view, self.tab_headers[1], "WITCH")
+
+        self.tabs = {"f1": self.main_tab, "f2": self.witch_tab}
 
         # set starting conditions
         self.prompt = self.world_prompt
-        self.main = self.world_view_wrapper
+        self.main = self.main_tab
+        #self.main = self.world_view_wrapper
         self.footer = urwid.Text("connection okay!", align='right')
         self.client_state.set_on_recv(self.on_server_message)
         super().__init__(header=self.header, body=self.main, footer=self.footer)
@@ -214,6 +223,8 @@ class GameMain(urwid.Frame):
             # TODO: this isn't getting caught by the server for some reason
             asyncio.ensure_future(self.client_state.send('COMMAND QUIT'), loop=self.loop)
             quit_client('')
+        elif key in self.tabs.keys():
+            self.body = self.tabs.get(key)
 
     def here_info(self):
         room_name = self.room.get("name")

--- a/client/tmclient/ui.py
+++ b/client/tmclient/ui.py
@@ -64,37 +64,49 @@ class TabHeader(urwid.LineBox):
     the tab contents.
     """
 
-    def __init__(self, contents, position="", selected=False):
+    def __init__(self, label, position="", selected=False):
 
         tl = '╭'
         tr = '╮'
 
-        self.contents = contents
+        self.label = label
+        self.contents = urwid.Text(self.label, align='center')
         self.position = position
 
         if position == 'first':
-            bl = '│'
-            br = '└'
+            if selected:
+                bl = '║'
+                br = '╙'
+            else:
+                bl = '├'
+                br = '┴'
         elif position == 'last':
-            bl = '┴'
-            br = '┤'
+            if selected:
+                bl = '╜'
+                bl = '║'
+            else:
+                bl = '┴'
+                br = '┤'
         else:
-            bl = '┴'
-            br = '┴'
+            if selected:
+                bl = '╜'
+                br = '╙'
+            else:
+                bl = '┴'
+                br = '┴'
+
         if selected:
             b = ' '
+            r = '║'
+            l = '║'
         else:
             b = '─'
+            r = '│'
+            l = '│'
 
-        super().__init__(contents, tlcorner=tl, trcorner=tr,
-                blcorner=bl, brcorner=br, bline = b)
-
-    def unselect(self):
-        self.__init__(self.contents, self.position, False)
-
-    def select(self):
-        self.__init__(self.contents, self.position, True)
-
+        super().__init__(self.contents, tlcorner=tl, trcorner=tr,
+                blcorner=bl, brcorner=br, bline=b,
+                lline =l, rline=r)
 
 
 class Screen(urwid.WidgetPlaceholder):
@@ -150,20 +162,19 @@ class GameTab(urwid.WidgetPlaceholder):
     Base interface for a tab within the main game area.
     """
 
-    def __init__(self, widget, tab, title):
+    def __init__(self, widget, tab_header):
         self.main = urwid.LineBox(widget, tlcorner='│', trcorner='│', tline='')
-        self.tab = tab
-        self.title = title
+        self.tab_header = tab_header
         self.in_focus = False
         super().__init__(self.main)
 
     def focus(self):
         self.in_focus = True
-        self.tab.select()
+        self.tab_header = TabHeader(self.tab_header.label, self.tab_header.position, True)
 
     def unfocus(self):
         self.in_focus = False
-        self.tab.unselect()
+        self.tab_header = TabHeader(self.tab_header.label, self.tab_header.position, False)
 
         
 

--- a/client/tmclient/ui.py
+++ b/client/tmclient/ui.py
@@ -50,6 +50,42 @@ def solidfill(s, theme='basic'):
     return urwid.AttrMap(urwid.SolidFill(s), theme)
 
 
+class DashedBox(urwid.LineBox):
+    def __init__(self, box_item):
+        super().__init__(box_item,
+                tlcorner='┌', tline='╌', lline='╎', trcorner='┐', blcorner='└',
+                rline='╎', bline='╌', brcorner='┘'
+                )
+
+class TabHeader(urwid.LineBox):
+    """
+    Stylizations for tab headers. Position can be 'first', 'last', or none for
+    default/medial tabs. Selected tab displays with no bottom, so it opens into
+    the tab contents.
+    """
+
+    def __init__(self, contents, position="", selected=False):
+
+        tl = '╭'
+        tr = '╮'
+
+        if position == 'first':
+            bl = '│'
+            br = '└'
+        elif position == 'last':
+            bl = '┴'
+            br = '┤'
+        else:
+            bl = '┴'
+            br = '┴'
+        if selected:
+            b = ' '
+        else:
+            b = '─'
+
+        super().__init__(contents, tlcorner=tl, trcorner=tr,
+                blcorner=bl, brcorner=br, bline = b)
+
 
 class Screen(urwid.WidgetPlaceholder):
     """

--- a/client/tmclient/ui.py
+++ b/client/tmclient/ui.py
@@ -135,6 +135,17 @@ class Screen(urwid.WidgetPlaceholder):
             return super(Screen, self).keypress(size, key)
 
 
+class GameTab(urwid.WidgetPlaceholder):
+    """
+    Base interface for a tab within the main game area.
+    """
+
+    def __init__(self, widget, tab, title):
+        self.main = urwid.LineBox(widget, tlcorner='│', trcorner='│', tline='')
+        self.tab = tab
+        self.title = title
+        super().__init__(self.main)
+        
 
 palettes = [
     ('reversed', 'standout', ''),

--- a/client/tmclient/ui.py
+++ b/client/tmclient/ui.py
@@ -69,6 +69,9 @@ class TabHeader(urwid.LineBox):
         tl = '╭'
         tr = '╮'
 
+        self.contents = contents
+        self.position = position
+
         if position == 'first':
             bl = '│'
             br = '└'
@@ -85,6 +88,13 @@ class TabHeader(urwid.LineBox):
 
         super().__init__(contents, tlcorner=tl, trcorner=tr,
                 blcorner=bl, brcorner=br, bline = b)
+
+    def unselect(self):
+        self.__init__(self.contents, self.position, False)
+
+    def select(self):
+        self.__init__(self.contents, self.position, True)
+
 
 
 class Screen(urwid.WidgetPlaceholder):
@@ -144,7 +154,17 @@ class GameTab(urwid.WidgetPlaceholder):
         self.main = urwid.LineBox(widget, tlcorner='│', trcorner='│', tline='')
         self.tab = tab
         self.title = title
+        self.in_focus = False
         super().__init__(self.main)
+
+    def focus(self):
+        self.in_focus = True
+        self.tab.select()
+
+    def unfocus(self):
+        self.in_focus = False
+        self.tab.unselect()
+
         
 
 palettes = [

--- a/client/tmclient/ui.py
+++ b/client/tmclient/ui.py
@@ -162,9 +162,10 @@ class GameTab(urwid.WidgetPlaceholder):
     Base interface for a tab within the main game area.
     """
 
-    def __init__(self, widget, tab_header):
+    def __init__(self, widget, tab_header, prompt):
         self.main = urwid.LineBox(widget, tlcorner='│', trcorner='│', tline='')
         self.tab_header = tab_header
+        self.prompt = prompt
         self.in_focus = False
         super().__init__(self.main)
 

--- a/client/tmclient/ui.py
+++ b/client/tmclient/ui.py
@@ -176,7 +176,6 @@ class GameTab(urwid.WidgetPlaceholder):
         self.in_focus = False
         self.tab_header = TabHeader(self.tab_header.label, self.tab_header.position, False)
 
-        
 
 palettes = [
     ('reversed', 'standout', ''),

--- a/server/tmserver/models.py
+++ b/server/tmserver/models.py
@@ -43,7 +43,7 @@ class ScriptEngine:
 
     def _say_handler(self, receiver, sender, action_args):
         if receiver.user_account:
-            msg = '{} says {}'.format(sender.name, action_args)
+            msg = '{} says, \"{}\"'.format(sender.name, action_args)
             receiver.user_account.hears(self.game_world, sender, msg)
 
     def add_handler(self, action, fn):

--- a/server/tmserver/tests/async_test.py
+++ b/server/tmserver/tests/async_test.py
@@ -95,7 +95,7 @@ async def test_game_command(event_loop, mock_logger, client):
     msg = await client.recv()
     assert msg == 'COMMAND OK'
     msg = await client.recv()
-    assert msg == 'vilmibm says hello'
+    assert msg == 'vilmibm says, "hello"'
     await client.close()
 
 async def setup_user(client, username, god=False):
@@ -161,7 +161,7 @@ async def test_witch_script(event_loop, mock_logger, client):
     await client.send('COMMAND pet')
     await client.recv()
     msg = await client.recv()
-    assert msg == 'snoozy says neigh neigh neigh i am horse'
+    assert msg == 'snoozy says, "neigh neigh neigh i am horse"'
     await client.close()
 
 

--- a/server/tmserver/world.py
+++ b/server/tmserver/world.py
@@ -34,6 +34,8 @@ class GameWorld:
             cls.handle_whisper(sender_obj, action_args)
         if action == 'look':
             cls.handle_look(sender_obj, action_args)
+        if action == 'refresh':
+            cls.handle_refresh(sender_obj, action_args)
 
         aoe = cls.area_of_effect(sender_obj)
         for o in aoe:
@@ -116,6 +118,15 @@ class GameWorld:
 
         for o in cls.area_of_effect(sender_obj):
             o.handle_action(cls, sender_obj, 'look', action_args)
+
+    @classmethod
+    def handle_refresh(cls, sender_obj, action_args):
+        msgs = []
+        here = sender_obj.contained_by
+        msgs.append('meta Current location: {}'.format(here.name))
+
+        for m in msgs:
+            sender_obj.user_account.hears(cls, sender_obj, m)
 
     @classmethod
     def area_of_effect(cls, sender_obj):

--- a/server/tmserver/world.py
+++ b/server/tmserver/world.py
@@ -121,12 +121,21 @@ class GameWorld:
 
     @classmethod
     def handle_refresh(cls, sender_obj, action_args):
+        # TODO: should the server dictate what text goes into the client's look
+        # panel, or should it pass through data for the client to format?
         msgs = []
-        here = sender_obj.contained_by
-        msgs.append('meta Current location: {}'.format(here.name))
+        room = sender_obj.contained_by
+        msgs.append('here [{}]'.format(room.name))
+        msgs.append('{}'.format(room.description))
 
-        for m in msgs:
-            sender_obj.user_account.hears(cls, sender_obj, m)
+        contents = []
+        for o in room.contains:
+            contents.append(o.name)
+        msgs.append('you see here ({pop}): {contents}'.format(
+            pop=len(contents),
+            contents=', '.join(contents)))
+
+        sender_obj.user_account.hears(cls, sender_obj, '\n'.join(msgs))
 
     @classmethod
     def area_of_effect(cls, sender_obj):

--- a/server/tmserver/world.py
+++ b/server/tmserver/world.py
@@ -34,8 +34,6 @@ class GameWorld:
             cls.handle_whisper(sender_obj, action_args)
         if action == 'look':
             cls.handle_look(sender_obj, action_args)
-        if action == 'refresh':
-            cls.handle_refresh(sender_obj, action_args)
 
         aoe = cls.area_of_effect(sender_obj)
         for o in aoe:
@@ -118,40 +116,6 @@ class GameWorld:
 
         for o in cls.area_of_effect(sender_obj):
             o.handle_action(cls, sender_obj, 'look', action_args)
-
-    @classmethod
-    def handle_refresh(cls, sender_obj, action_args):
-        # TODO: should the server dictate what text goes into the client's info
-        # panel, or should it pass through data for the client to format?
-
-        msgs = []
-
-        ## here panel
-        here = []
-        room = sender_obj.contained_by
-        here.append('here [{}]'.format(room.name))
-        here.append('{}'.format(room.description))
-
-        contents = []
-        for o in room.contains:
-            contents.append(o.name)
-        here.append('you see here ({pop}): {contents}'.format(
-            pop=len(contents),
-            contents=', '.join(contents)))
-
-        msgs.append('\n'.join(here))
-
-        ## user info panel
-        user = []
-        # TODO: where did user names actually go? the 'name' field returns a
-        # description instead.
-        user.append('info <{desc} named "{name}">'.format(
-            desc=sender_obj.name,
-            name=sender_obj.description
-            ))
-        msgs.append('\n'.join(user))
-        for m in msgs:
-            sender_obj.user_account.hears(cls, sender_obj, m)
 
     @classmethod
     def area_of_effect(cls, sender_obj):

--- a/server/tmserver/world.py
+++ b/server/tmserver/world.py
@@ -121,21 +121,37 @@ class GameWorld:
 
     @classmethod
     def handle_refresh(cls, sender_obj, action_args):
-        # TODO: should the server dictate what text goes into the client's look
+        # TODO: should the server dictate what text goes into the client's info
         # panel, or should it pass through data for the client to format?
+
         msgs = []
+
+        ## here panel
+        here = []
         room = sender_obj.contained_by
-        msgs.append('here [{}]'.format(room.name))
-        msgs.append('{}'.format(room.description))
+        here.append('here [{}]'.format(room.name))
+        here.append('{}'.format(room.description))
 
         contents = []
         for o in room.contains:
             contents.append(o.name)
-        msgs.append('you see here ({pop}): {contents}'.format(
+        here.append('you see here ({pop}): {contents}'.format(
             pop=len(contents),
             contents=', '.join(contents)))
 
-        sender_obj.user_account.hears(cls, sender_obj, '\n'.join(msgs))
+        msgs.append('\n'.join(here))
+
+        ## user info panel
+        user = []
+        # TODO: where did user names actually go? the 'name' field returns a
+        # description instead.
+        user.append('info <{desc} named "{name}">'.format(
+            desc=sender_obj.name,
+            name=sender_obj.description
+            ))
+        msgs.append('\n'.join(user))
+        for m in msgs:
+            sender_obj.user_account.hears(cls, sender_obj, m)
 
     @classmethod
     def area_of_effect(cls, sender_obj):


### PR DESCRIPTION
relevant to #13 and #41, i've stubbed/hardcoded in some UI changes that i think helps move the client forward. most of this was just helpful for me to visually block out the client a little more, while also learning my way around urwid and the codebase in general.

specifically:
* added a tip on the main/login screen to push 'ESC' to close windows (this took me a moment to figure out on my own when i first launched the client)
* added more info to the registration menu, including noting the hardcoded password minimum
* built on the existing main game window draft:
  * stubbed out some text that prints in game window on successful login
  * added `\refresh` command, which repopulates the room info and character info panels (in the future, if those panels update dynamically, this command will be obsolete)
* minor appearance adjustments:
  * added quotation marks around speech
  * added some styling to the banner to make it visually distinct from main game area

i'm not sure if this is really PR-ready, but i feel like i'm hitting a wall with what i can meaningfully work on at the moment; i'm happy to hold these changes back until more server-side work progresses if that's the sensible thing to do!