### PR TITLE
first pass on data API

### DIFF
--- a/server/tmserver/tests/async_test.py
+++ b/server/tmserver/tests/async_test.py
@@ -252,7 +252,7 @@ async def test_data_malformed_path(event_loop, mock_logger, client):
         msg = await client.recv()
         assert msg == 'ERROR: malformed data request: {}'.format(bad)
 
-    client.close()
+    await client.close()
 
 @pytest.mark.asyncio
 async def test_data_unknown_path(event_loop, mock_logger, client):
@@ -262,7 +262,7 @@ async def test_data_unknown_path(event_loop, mock_logger, client):
     msg = await client.recv()
     assert msg == 'ERROR: Unknown data API path ぶぶぶぶぶぶぶ'
 
-    client.close()
+    await client.close()
 
 @pytest.mark.asyncio
 async def test_roominfo(event_loop, mock_logger, client):
@@ -286,7 +286,7 @@ async def test_roominfo(event_loop, mock_logger, client):
          'description': 'a gaseous cloud'},
         {'name': 'cigar',
          'description': 'a fancy cigar ready for lighting'}]
-    client.close()
+    await client.close()
 
 @pytest.mark.asyncio
 async def test_playerinfo(event_loop, mock_logger, client):
@@ -302,4 +302,4 @@ async def test_playerinfo(event_loop, mock_logger, client):
         'playername': vil.player_obj.name,
         'description': vil.player_obj.description
     }
-    client.close()
+    await client.close()

--- a/server/tmserver/world.py
+++ b/server/tmserver/world.py
@@ -156,3 +156,23 @@ class GameWorld:
     def remove_from(cls, outer_obj, inner_obj):
         outer_obj.remove_from(inner_obj)
 
+
+    @classmethod
+    def data_request(cls, user_account, path):
+        # TODO generalize a bit
+        # TODO add 'world' path for dumping the world state. consider threading
+        # since it could lock up the CPU.
+        if path == 'roominfo':
+            room = user_account.player_obj.contained_by
+            return {'name': room.name,
+                    'description': room.description,
+                    'objects': [dict(name=o.name,
+                                     description=o.description)
+                                for o in room.contains]}
+        elif path == 'playerinfo':
+            player_obj = user_account.player_obj
+            return {'username': user_account.username,
+                    'playername': player_obj.name,
+                    'description': player_obj.description}
+        else:
+            raise ClientException('Unknown data API path {}'.format(path))


### PR DESCRIPTION
this PR:

- adds support for a new type of client message, `DATA`
- "routes" based on a path; for now, just `roominfo` and `playerinfo`

so if you send the string `DATA roominfo` from the client, you will (asynchronously) get back a `DATA roominfo {...}`.

`msg.split(' ', maxsplit=2)[2]` on the string the server gets yields a JSON string. Right now the keys for `roominfo` are `name`, `description`, and `objects`. the keys for `playerinfo` are `username`, `playername`, and `description`.