### PR TITLE
making main game text area scrollable

### DIFF
--- a/client/tmclient/screens.py
+++ b/client/tmclient/screens.py
@@ -109,9 +109,12 @@ class GameMain(urwid.Frame):
         self.client_state = client_state
         self.loop = loop
         self.banner = urwid.Text('welcome 2 tildemush, u are jacked in')
-        self.game_text = urwid.Pile([urwid.Text('lol game stuff happens here')])
+        self.game_walker = urwid.SimpleListWalker([
+            urwid.Text('you have reconstituted into tildemush')
+            ])
+        self.game_text = urwid.ListBox(self.game_walker)
         self.main = urwid.Columns([
-            urwid.Filler(self.game_text),
+            self.game_text,
             urwid.Pile([
                 urwid.Filler(urwid.Text('details about your current room')),
                 urwid.Filler(urwid.Text('i donno a map?')),
@@ -126,8 +129,11 @@ class GameMain(urwid.Frame):
     async def on_server_message(self, server_msg):
         if server_msg == 'COMMAND OK':
             pass
-        self.game_text.contents.append(
-            (urwid.Text(server_msg), self.game_text.options()))
+
+        new_line = urwid.Text(server_msg)
+        self.game_walker.append(new_line)
+        self.game_walker.set_focus(len(self.game_walker)-1)
+        self.focus_prompt()
 
     def focus_prompt(self):
         self.focus_position = 'footer'


### PR DESCRIPTION
this PR:
* implements the main game text as a listbox, which allows scrolling (closes #36)

future work:
* capture `pgup pgdn home end` keypresses to scroll through text
* make a scrollback cap, which users should be able to set manually for their client

question:
* i personally prefer if the initial text starts from the bottom and pushes upwards; currently, the initial text starts from the top and fills downwards. this is a pretty small cosmetic tweak, does either one way or the other make more sense? should this also be part of user-modifiable client settings? (i'm leaning towards 'make as many cosmetic tweaks adjustable by users as is practical', to be honest)