### PR TITLE
remove the "by user" part of witch macro

### DIFF
--- a/server/tmserver/live_test.py
+++ b/server/tmserver/live_test.py
@@ -22,7 +22,7 @@ def setup_horse():
     script_rev = ScriptRevision.create(
         script=horse_script,
         code='''
-            (witch "horse" by "vilmibm"
+            (witch "horse"
               (has {"num-pets" 0
                     "name" "snoozy"
                     "description" "a horse"})

--- a/server/tmserver/scripting.py
+++ b/server/tmserver/scripting.py
@@ -10,24 +10,25 @@ WITCH_HEADER = '(require [tmserver.witch_header [*]])'
 # Note an awful thing here; since we call .format on the script templates, we
 # have to escape the WITCH macro's {}. {{}} is not the Hy that we want, but we
 # need it in the templates.
+# TODO consider using shortname instead of name for the string passed to (witch)
 SCRIPT_TEMPLATES = {
     'item': '''
-    (witch "{name}" by "TODO fix macro to not need author"
+    (witch "{name}"
       (has {{"name" "{name}"
             "description" "{description}"}}))
     ''',
     'player': '''
-    (witch "{name}" by "TODO fix macro to not need author"
+    (witch "{name}"
       (has {{"name" "{name}"
             "description" "{description}"}}))
     ''',
     'room': '''
-    (witch "{name}" by "TODO fix macro to not need author"
+    (witch "{name}"
       (has {{"name" "{name}"
             "description" "{description}"}}))
     ''',
     'exit': '''
-    (witch "{name}" by "TODO fix macro to not need author"
+    (witch "{name}"
       (has {{"name" "{name}"
             "description" "{description}"
             "target" "{target_room_name}"}})
@@ -35,18 +36,13 @@ SCRIPT_TEMPLATES = {
         (tell-sender "move" (get-data "target"))))
     ''',
     'portkey': '''
-    (witch "{name}" by "TODO fix macro to not need author"
+    (witch "{name}"
       (has {{"name" "{name}"
             "description" "{description}"
             "target" "{target_room_name}"}})
       (hears "touch"
         (tell-sender "move" (get-data "target"))))
     '''}
-
-def get_template(obj_type, name, description="A trinket"):
-    # TODO accept an arbitrary dict for formatting
-    return SCRIPT_TEMPLATES[obj_type].format(name=name,
-                                             description=description)
 
 class ScriptEngine:
     CONTAIN_TYPES = {'acquired', 'entered', 'lost', 'freed'}

--- a/server/tmserver/tests/async_test.py
+++ b/server/tmserver/tests/async_test.py
@@ -146,7 +146,7 @@ async def test_witch_script(event_loop, mock_logger, client):
     script_rev = ScriptRevision.create(
         script=horse_script,
         code='''
-            (witch "horse" by "vilmibm"
+            (witch "horse"
               (has {"num-pets" 0
                     "name" "snoozy"
                     "description" "a horse"})

--- a/server/tmserver/tests/game_object_test.py
+++ b/server/tmserver/tests/game_object_test.py
@@ -126,7 +126,7 @@ class GameObjectScriptEngineTest(TildemushTestCase):
         self.script_rev = ScriptRevision.create(
             script=self.script,
             code='''
-            (witch "horse" by "vilmibm"
+            (witch "horse"
               (has {"num-pets" 0
                     "name" "snoozy"
                     "description" "a horse"})

--- a/server/tmserver/witch_header.hy
+++ b/server/tmserver/witch_header.hy
@@ -4,11 +4,10 @@
 #_("TODO support additional args, here. right now, they have to be one big string.")
 (defmacro tell-sender [action args] `(.tell-sender receiver sender ~action ~args))
 
-#_("TODO what to do with script_name and author_name?")
 #_("TODO eventually decide on cmd-args handling")
 
 (defmacro witch
-  [script_name _ author_name data &rest actions]
+  [script_name data &rest actions]
   (setv se (gensym))
   (setv hp (gensym))
   `(do
@@ -25,7 +24,7 @@
 
 
 
-#_(setv hmm (witch "horse" by "vilmibm"
+#_(setv hmm (witch "horse"
                 (has {"num-pets" 0})
                 (hears "pet"
                        (set-data "num-pets"

--- a/server/tmserver/world.py
+++ b/server/tmserver/world.py
@@ -5,7 +5,7 @@ from slugify import slugify
 from .config import get_db
 from .errors import ClientException
 from .models import Contains, GameObject, Contains, Script
-from .scripting import get_template
+
 DIRECTIONS = {'north', 'south', 'west', 'east', 'above', 'below'}
 CREATE_TYPES = {'room', 'exit', 'item'}
 CREATE_RE = re.compile(r'^([^ ]+) "([^"]+)" (.*)$')


### PR DESCRIPTION
i donno maybe having someone's username is nice? so when you're reading out of context you are reminded of the author?

or is it just confusing noise?

either way it didn't mean anything; any nonsense could go in that spot...

Fixes #60 