### PR TITLE
List exits

### DIFF
--- a/server/tmserver/models.py
+++ b/server/tmserver/models.py
@@ -168,6 +168,7 @@ class GameObject(BaseModel, ScriptedObjectMixin):
                 author=author,
                 shortname=shortname,
                 script_revision=scriptrev)
+            game_obj.init_scripting()
 
         return game_obj
 

--- a/server/tmserver/scripting.py
+++ b/server/tmserver/scripting.py
@@ -117,16 +117,18 @@ class ScriptedObjectMixin:
     @property
     def engine(self):
         if not hasattr(self, '_engine'):
-            if self.script_revision is None:
-                self._engine = ScriptEngine()
-            else:
-                try:
-                    self._engine = self._execute_script(self.script_revision.code)
-                except Exception as e:
-                    raise WitchException(
-                        ';_; There is a problem with your witch script: {}'.format(e))
-
+            self.init_scripting()
         return self._engine
+
+    def init_scripting(self):
+        if self.script_revision is None:
+            self._engine = ScriptEngine()
+        else:
+            try:
+                self._engine = self._execute_script(self.script_revision.code)
+            except Exception as e:
+                raise WitchException(
+                    ';_; There is a problem with your witch script: {}'.format(e))
 
     def handle_action(self, game_world, sender_obj, action, action_args):
         self._ensure_world(game_world)

--- a/server/tmserver/tests/async_test.py
+++ b/server/tmserver/tests/async_test.py
@@ -302,6 +302,27 @@ async def test_client_state(event_loop, mock_logger, client):
     GameWorld.put_into(tricorder, music_app)
     GameWorld.put_into(music_app, klingon_opera)
 
+    import ipdb; ipdb.set_trace()
+    GameObject.create_scripted_object(
+        'room', god, 'jeffries-tube-god', dict(
+            name='Jeffries Tube',
+            description='A cramped little space used for maintenance.'))
+    GameObject.create_scripted_object(
+        'room', god, 'replicator-room-god', dict(
+            name='Replicator Room',
+            description="Little more than a closet, you can use this room to interact with the replicator in case you don't want to make an order a the bar."))
+
+    GameWorld.put_into(room, god.player_obj)
+    GameWorld.create_exit(
+        god.player_obj,
+        'Sliding Door',
+        'east replicator-room-god An automatic, shiny sliding door')
+    GameWorld.create_exit(
+        god.player_obj,
+        'Hatch',
+        'below jeffries-tube-god A small hatch, just big enough for a medium sized humanoid.')
+    GameWorld.remove_from(room, god.player_obj)
+
     await client.send('LOGIN vilmibm:foobarbazquux')
     await client.recv()
     await client.recv()
@@ -326,15 +347,18 @@ async def test_client_state(event_loop, mock_logger, client):
                  'description': 'a chess game with four decks'},
                 {'name': 'weird drink',
                  'description': 'an in-house invention of Guinan. It is purple and fizzes ominously.'},
+                {'name': 'Sliding Door',
+                 'description': 'An automatic, shiny sliding door'},
+                {'name': 'Hatch',
+                 'description': 'A small hatch, just big enough for a medium sized humanoid.'}
             ],
             'exits': {
-                'north': None,
-                'south': None,
-                'east': None,
-                'west': None,
-                'above': None,
-                'below': None,
-            }
+                'east': {
+                    'exit_name': 'Sliding Door',
+                    'room_name': 'Replicator Room'},
+                'below': {
+                    'exit_name': 'Hatch',
+                    'room_name': 'Jeffries Tube'}}
         },
         'inventory': [
             {'name':'tricorder',

--- a/server/tmserver/tests/async_test.py
+++ b/server/tmserver/tests/async_test.py
@@ -302,7 +302,6 @@ async def test_client_state(event_loop, mock_logger, client):
     GameWorld.put_into(tricorder, music_app)
     GameWorld.put_into(music_app, klingon_opera)
 
-    import ipdb; ipdb.set_trace()
     GameObject.create_scripted_object(
         'room', god, 'jeffries-tube-god', dict(
             name='Jeffries Tube',

--- a/server/tmserver/tests/game_object_test.py
+++ b/server/tmserver/tests/game_object_test.py
@@ -8,6 +8,22 @@ from ..world import GameWorld
 
 from .tm_test_case import TildemushTestCase
 
+class CreateScriptedObjectTest(TildemushTestCase):
+    def setUp(self):
+        super().setUp()
+        self.vil = UserAccount.create(
+            username='vilmibm',
+            password='foobarbazquux')
+
+    def test_data_initialized(self):
+        banana = GameObject.create_scripted_object(
+            'item', self.vil, 'banana-vilmibm', dict(
+                name='A Banana',
+                description='Still green.'))
+        assert banana.data == dict(
+            name='A Banana',
+            description='Still green.')
+
 class GameObjectDataTest(TildemushTestCase):
     """This test merely ensures the ensure, get, and set data stuff works okay.
     Scripts aren't involved."""


### PR DESCRIPTION
The format I went with is slightly different than we discussed in IRC:

```python
{'exits': {
  'north': {
    'room_name': 'Replicator Room',
    'exit_name': 'Sliding Door'
  }, 
  'below': {
     'room_name': 'Jeffries Tube',
     'exit_name': 'Small Hatch',}}}
```

If no exit exists for a given direction, it's not in `exits`. We've talked about only using `room_name` in the minimap, but I figured `exit_name` might come in handy eventually.

Fixes #68 