### PR TITLE
Inventory commands

### DIFF
--- a/server/tmserver/models.py
+++ b/server/tmserver/models.py
@@ -212,6 +212,7 @@ class GameObject(BaseModel, ScriptedObjectMixin):
 
         In all cases, case is ignored.
         """
+        # TODO strip color codes from name
         shortname = self.shortname.lower()
         name = self.name.lower()
         match_string = match_string.lower()

--- a/server/tmserver/models.py
+++ b/server/tmserver/models.py
@@ -199,6 +199,42 @@ class GameObject(BaseModel, ScriptedObjectMixin):
             return self.author
         return None
 
+    def fuzzy_match(self, match_string):
+        """Given a string, return whether or not it could be considered as
+        referencing this object. Roughly, this means:
+
+        - is it an exact match on shortname?
+        - is it an exact match on name?
+        - is it a prefix for name?
+        - is it a prefix for shortname?
+        - does it appear as a substring in name?
+        - does it appear as a substring in shortname?
+
+        In all cases, case is ignored.
+        """
+        shortname = self.shortname.lower()
+        name = self.name.lower()
+        match_string = match_string.lower()
+        if match_string == shortname:
+            return True
+
+        if match_string == name:
+            return True
+
+        if name.startswith(match_string):
+            return True
+
+        if shortname.startswith(match_string):
+            return True
+
+        if match_string in name:
+            return True
+
+        if match_string in shortname:
+            return True
+
+        return False
+
     def can_carry(self, target_obj):
         return self._can_perm('carry', target_obj)
 

--- a/server/tmserver/tests/async_test.py
+++ b/server/tmserver/tests/async_test.py
@@ -635,7 +635,7 @@ async def test_handle_put(event_loop, mock_logger, client):
 
     phaser.perms.carry = Permission.WORLD
     phaser.perms.save()
-    space_chest.perms.carry = Permission.WORLD
+    space_chest.perms.execute = Permission.WORLD
     space_chest.perms.save()
 
     GameWorld.put_into(foyer, phaser)
@@ -652,5 +652,38 @@ async def test_handle_put(event_loop, mock_logger, client):
     #assert msg.startswith('STATE')
     msg = await client.recv()
     assert msg == 'You put a phaser in Fancy Space Chest'
+
+    await client.close()
+
+@pytest.mark.asyncio
+async def test_handle_remove(event_loop, mock_logger, client):
+    god = UserAccount.get(UserAccount.username=='god')
+    foyer = GameObject.get(GameObject.shortname=='foyer')
+    phaser = GameObject.create_scripted_object(
+        'item', god, 'phaser-god', dict(
+            name='a phaser',
+            description='watch where u point it'))
+    space_chest = GameObject.create_scripted_object(
+        'item', god, 'space-chest-god', dict(
+            name='Fancy Space Chest',
+            description="It's like a fantasy chest but palette swapped."))
+
+    phaser.perms.carry = Permission.WORLD
+    phaser.perms.save()
+    space_chest.perms.execute = Permission.WORLD
+    space_chest.perms.save()
+
+    GameWorld.put_into(foyer, space_chest)
+    GameWorld.put_into(space_chest, phaser)
+
+    await setup_user(client, 'vilmibm')
+
+    await client.send('COMMAND remove phaser from chest')
+    msg = await client.recv()
+    assert msg == 'COMMAND OK'
+    msg = await client.recv()
+    assert msg.startswith('STATE')
+    msg = await client.recv()
+    assert msg == 'You remove a phaser from Fancy Space Chest and carry it with you.'
 
     await client.close()

--- a/server/tmserver/tests/game_object_test.py
+++ b/server/tmserver/tests/game_object_test.py
@@ -11,14 +11,21 @@ from .tm_test_case import TildemushTestCase
 class FuzzyMatchTest(TildemushTestCase):
     def setUp(self):
         super().setUp()
-        vil = UserAccount.create(
+        self.vil = UserAccount.create(
             username='vilmibm',
             password='foobarbazquux')
 
         self.phaser = GameObject.create_scripted_object(
-            'item', vil, 'phaser-vilmibm-666', dict(
+            'item', self.vil, 'phaser-vilmibm-666', dict(
                 name='Federation Phaser',
                 description='Looks like a remote control, but is far deadlier. You should probably leave it set for stun.'))
+
+    def test_ignores_color_codes(self):
+        rainbow = GameObject.create_scripted_object(
+            'item', self.vil, 'contrived-example-vilmibm', dict(
+                name='a {red}r{orange}a{yellow}i{green}n{blue}b{indigo}o{violet}w{/}',
+                description="all the way across the sky."))
+        assert rainbow.fuzzy_match('rainbow')
 
     def test_exact_name_match(self):
         assert self.phaser.fuzzy_match('Federation Phaser')

--- a/server/tmserver/tests/game_object_test.py
+++ b/server/tmserver/tests/game_object_test.py
@@ -8,6 +8,44 @@ from ..world import GameWorld
 
 from .tm_test_case import TildemushTestCase
 
+class FuzzyMatchTest(TildemushTestCase):
+    def setUp(self):
+        super().setUp()
+        vil = UserAccount.create(
+            username='vilmibm',
+            password='foobarbazquux')
+
+        self.phaser = GameObject.create_scripted_object(
+            'item', vil, 'phaser-vilmibm-666', dict(
+                name='Federation Phaser',
+                description='Looks like a remote control, but is far deadlier. You should probably leave it set for stun.'))
+
+    def test_exact_name_match(self):
+        assert self.phaser.fuzzy_match('Federation Phaser')
+        assert self.phaser.fuzzy_match('federation phaser')
+
+    def test_exact_shortname_match(self):
+        assert self.phaser.fuzzy_match('phaser-vilmibm-666')
+        assert self.phaser.fuzzy_match('pHaSeR-ViLmIbM-666')
+
+    def test_fuzzy_name_match(self):
+        assert self.phaser.fuzzy_match('federation')
+        assert self.phaser.fuzzy_match('Federation')
+
+    def test_fuzzy_shortname_match(self):
+        assert self.phaser.fuzzy_match('phaser-vil')
+        assert self.phaser.fuzzy_match('pHasEr-vIl')
+
+    def test_substr_name_match(self):
+        # yeah this is contrived sorry
+        assert self.phaser.fuzzy_match('ederation phase')
+        assert self.phaser.fuzzy_match('edErAtIoN pHase')
+
+    def test_substr_shortname_match(self):
+        assert self.phaser.fuzzy_match('ser-vil')
+        assert self.phaser.fuzzy_match('sEr-vIl')
+
+
 class CreateScriptedObjectTest(TildemushTestCase):
     def setUp(self):
         super().setUp()

--- a/server/tmserver/tests/inventory_test.py
+++ b/server/tmserver/tests/inventory_test.py
@@ -2,40 +2,42 @@ from unittest import mock
 
 from .tm_test_case import TildemushTestCase
 from ..errors import ClientException
-from ..models import UserAccount, GameObject
+from ..models import UserAccount, GameObject, Permission
 from ..world import GameWorld
 
-def setup_scene():
-    foyer = GameObject.get(GameObject.shortname=='foyer')
-    god = UserAccount.get(UserAccount.username=='god')
-
-    vil_ua = UserAccount.create(
-        username='vilmibm',
-        password='foobarbazquux')
-
-    can = GameObject.create_scripted_object(
-        'item', god, 'can-god', dict(
-            name='A Rusted Tin Can',
-            description='The label has been torn off. A patch of adhesive is still a little sticky, though the metal is all rusted over. Something about it is unsettling.'))
-    bag = GameObject.create_scripted_object(
-        'item', god, 'bag-god', dict(
-            name='A Garbage Bag',
-            description="It's just a garbage bag. The black, glossy kind. You wonder how much stuff you could fit in there."))
-
-    # TODO initial perms? by default, things are pretty open. i'll restrict as
-    # needed unless that sucks...
-    GameWorld.put_into(foyer, can)
-    GameWorld.put_into(foyer, bag)
-    GameWorld.put_into(foyer, vil_ua.player_obj)
-
-    return vil_ua.player_obj
-
-@mock.patch('tmserver.world.GameWorld.user_hears')
-class GetTest(TildemushTestCase):
+class InventoryTestCase(TildemushTestCase):
     def setUp(self):
         super().setUp()
-        self.vil = setup_scene()
+        foyer = GameObject.get(GameObject.shortname=='foyer')
+        god = UserAccount.get(UserAccount.username=='god')
 
+        vil_ua = UserAccount.create(
+            username='vilmibm',
+            password='foobarbazquux')
+
+        can = GameObject.create_scripted_object(
+            'item', god, 'can-god', dict(
+                name='A Rusted Tin Can',
+                description='The label has been torn off. A patch of adhesive is still a little sticky, though the metal is all rusted over. Something about it is unsettling.'))
+        bag = GameObject.create_scripted_object(
+            'item', god, 'bag-god', dict(
+                name='A Garbage Bag',
+                description="It's just a garbage bag. The black, glossy kind. You wonder how much stuff you could fit in there."))
+
+        # TODO initial perms? by default, things are pretty open. i'll restrict as
+        # needed unless that sucks...
+        GameWorld.put_into(foyer, can)
+        GameWorld.put_into(foyer, bag)
+        GameWorld.put_into(foyer, vil_ua.player_obj)
+
+        self.foyer = foyer
+        self.god = god
+        self.vil = vil_ua.player_obj
+        self.bag = bag
+        self.can = can
+
+@mock.patch('tmserver.world.GameWorld.user_hears')
+class GetTest(InventoryTestCase):
     def test_obj_not_found(self, _):
         with self.assertRaisesRegex(
                 ClientException,
@@ -43,19 +45,36 @@ class GetTest(TildemushTestCase):
             GameWorld.handle_get(self.vil, 'shoe')
 
     def test_obj_denied(self, _):
-        pass
+        self.can.perms.carry = Permission.OWNER
+        self.can.perms.save()
 
-    def test_success(self, _):
-        pass
+        with self.assertRaisesRegex(
+                ClientException,
+                'You grab a hold of A Rusted Tin Can but'):
+            GameWorld.handle_get(self.vil, 'can')
 
-    def test_ambiguity(self, _):
-        pass
+    def test_success(self, mock_hears):
+        GameWorld.handle_get(self.vil, 'can')
+        assert self.can in self.vil.contains
+        assert mock_hears.called
+
+    def test_ambiguity(self, mock_hears):
+        shiny_can = GameObject.create_scripted_object(
+            'item', self.god, 'can-shiny-god', dict(
+                name='A New, Shiny Tin Can',
+                description="A new can. Not even adhesive on this. You can see yourself in its reflection but you're all ripply."))
+        GameWorld.put_into(self.foyer, shiny_can)
+        assert shiny_can in self.foyer.contains
+        assert self.can in self.foyer.contains
+        assert shiny_can.fuzzy_match('can')
+        assert self.can.fuzzy_match('can')
+        GameWorld.handle_get(self.vil, 'can')
+        assert self.can in self.vil.contains
+        assert shiny_can not in self.vil.contains
+        assert mock_hears.called
 
 
-class DropTest(TildemushTestCase):
-    def test_obj_not_found(self):
-        pass
-
+class DropTest(InventoryTestCase):
     def test_success(self):
         pass
 

--- a/server/tmserver/tests/inventory_test.py
+++ b/server/tmserver/tests/inventory_test.py
@@ -1,0 +1,119 @@
+from unittest import mock
+
+from .tm_test_case import TildemushTestCase
+from ..errors import ClientException
+from ..models import UserAccount, GameObject
+from ..world import GameWorld
+
+def setup_scene():
+    foyer = GameObject.get(GameObject.shortname=='foyer')
+    god = UserAccount.get(UserAccount.username=='god')
+
+    vil_ua = UserAccount.create(
+        username='vilmibm',
+        password='foobarbazquux')
+
+    can = GameObject.create_scripted_object(
+        'item', god, 'can-god', dict(
+            name='A Rusted Tin Can',
+            description='The label has been torn off. A patch of adhesive is still a little sticky, though the metal is all rusted over. Something about it is unsettling.'))
+    bag = GameObject.create_scripted_object(
+        'item', god, 'bag-god', dict(
+            name='A Garbage Bag',
+            description="It's just a garbage bag. The black, glossy kind. You wonder how much stuff you could fit in there."))
+
+    # TODO initial perms? by default, things are pretty open. i'll restrict as
+    # needed unless that sucks...
+    GameWorld.put_into(foyer, can)
+    GameWorld.put_into(foyer, bag)
+    GameWorld.put_into(foyer, vil_ua.player_obj)
+
+    return vil_ua.player_obj
+
+@mock.patch('tmserver.world.GameWorld.user_hears')
+class GetTest(TildemushTestCase):
+    def setUp(self):
+        super().setUp()
+        self.vil = setup_scene()
+
+    def test_obj_not_found(self, _):
+        with self.assertRaisesRegex(
+                ClientException,
+                'You look in vain for shoe.'):
+            GameWorld.handle_get(self.vil, 'shoe')
+
+    def test_obj_denied(self, _):
+        pass
+
+    def test_success(self, _):
+        pass
+
+    def test_ambiguity(self, _):
+        pass
+
+
+class DropTest(TildemushTestCase):
+    def test_obj_not_found(self):
+        pass
+
+    def test_success(self):
+        pass
+
+    def test_ambiguity(self):
+        pass
+
+class PutTest(TildemushTestCase):
+    def test_malformed(self):
+        pass
+
+    def test_target_not_found(self):
+        pass
+
+    def test_target_in_inv(self):
+        pass
+
+    def test_target_in_room(self):
+        pass
+
+    def test_container_in_inv(self):
+        pass
+
+    def test_container_in_room(self):
+        pass
+
+    def test_container_not_found(self):
+        pass
+
+    def test_target_denied(self):
+        pass
+
+    def test_container_denied(self):
+        pass
+
+class RemoveTest(TildemushTestCase):
+    def test_malformed(self):
+        pass
+
+    def test_target_not_found(self):
+        pass
+
+    def test_target_in_inv(self):
+        pass
+
+    def test_target_in_room(self):
+        pass
+
+    def test_container_in_inv(self):
+        pass
+
+    def test_container_in_room(self):
+        pass
+
+    def test_container_not_found(self):
+        pass
+
+    def test_target_denied(self):
+        pass
+
+    def test_container_denied(self):
+        pass

--- a/server/tmserver/util.py
+++ b/server/tmserver/util.py
@@ -1,0 +1,12 @@
+import re
+
+STRIP_COLOR_RE = re.compile(r'{[^}]+}')
+COLLAPSE_WHITESPACE_RE = re.compile(r'\s+')
+
+def strip_color_codes(string):
+    """returns string with {color} {codes} {/} removed"""
+    return collapse_whitespace(STRIP_COLOR_RE.sub('', string))
+
+def collapse_whitespace(string):
+    return COLLAPSE_WHITESPACE_RE.sub(' ', string).rstrip().lstrip()
+

--- a/server/tmserver/world.py
+++ b/server/tmserver/world.py
@@ -267,7 +267,7 @@ class GameWorld:
             raise ClientException(OBJECT_NOT_FOUND.format(target_obj_str))
 
         if not sender_obj.can_carry(target_obj):
-            raise ClientException(OBJECT_DENIED.format(target_obj_str))
+            raise ClientException(OBJECT_DENIED.format(target_obj.name))
 
         container_obj = None
         for obj in sender_obj.contains:
@@ -289,7 +289,7 @@ class GameWorld:
         if not sender_obj.can_execute(container_obj):
             raise ClientException(
                 'You try as hard as you can, but you are unable to pry open {}'.format(
-                    container_obj))
+                    container_obj.name))
 
         cls.put_into(container_obj, target_obj)
 

--- a/server/tmserver/world.py
+++ b/server/tmserver/world.py
@@ -349,7 +349,7 @@ class GameWorld:
             raise ClientException(OBJECT_NOT_FOUND.format(target_obj_str))
 
         if not sender_obj.can_carry(target_obj):
-            raise ClientException(OBJECT_DENIED).format(target_obj.name)
+            raise ClientException(OBJECT_DENIED.format(target_obj.name))
 
         cls.put_into(sender_obj, target_obj)
         cls.user_hears(sender_obj, sender_obj, 'You remove {} from {} and carry it with you.'.format(

--- a/server/tmserver/world.py
+++ b/server/tmserver/world.py
@@ -286,7 +286,7 @@ class GameWorld:
         if container_obj is None:
             raise ClientException(OBJECT_NOT_FOUND.format(container_obj_str))
 
-        if not sender_obj.can_carry(container_obj):
+        if not sender_obj.can_execute(container_obj):
             raise ClientException(
                 'You try as hard as you can, but you are unable to pry open {}'.format(
                     container_obj))

--- a/server/tmserver/world.py
+++ b/server/tmserver/world.py
@@ -155,7 +155,6 @@ class GameWorld:
         for o in aoe:
             o.handle_action(cls, sender_obj, action, action_args)
 
-
     @classmethod
     def all_active_objects(cls):
         """This method assumes that if an object is contained by something
@@ -186,17 +185,18 @@ class GameWorld:
            /get a banana
            /get Banana
         """
-        obj_string = action_args
+        # TODO eventually, generalize object resolution for various scopes. Consider player objects.
+        match_string = action_args
         found = None
         for obj in sender_obj.contained_by.contains:
             if obj.is_player_obj:
                 continue
-            if obj.fuzzy_match(obj_string):
+            if obj.fuzzy_match(match_string):
                 found = obj
                 break
 
         if found is None:
-            raise ClientException('You look in vain for something called {}.'.format(obj_string))
+            raise ClientException('You look in vain for something called {}.'.format(match_string))
 
         if not sender_obj.can_carry(found):
             raise ClientException(
@@ -207,8 +207,20 @@ class GameWorld:
         cls.user_hears(sender_obj, sender_obj, 'You grab {}.'.format(found.name))
 
     @classmethod
-    def handle_drop(cls, sender_obj, action_arsg):
-        pass
+    def handle_drop(cls, sender_obj, action_args):
+        # TODO eventually, generalize object resolution for various scopes. Consider player objects.
+        match_string = action_args
+        found = None
+        for obj in sender_obj.contains:
+            if obj.fuzzy_match(match_string):
+                found = obj
+                break
+
+        if found is None:
+            raise ClientException('You look in vain for something called {}.'.format(obj_string))
+
+        cls.put_into(sender_obj.contained_by, found)
+        cls.user_hears(sender_obj, sender_obj, 'You drop {}.'.format(found.name))
 
     @classmethod
     def handle_put(cls, sender_obj, action_arsg):

--- a/server/tmserver/world.py
+++ b/server/tmserver/world.py
@@ -663,6 +663,8 @@ class GameWorld:
         outer_obj.handle_action(cls, inner_obj, 'contain',  'acquired')
         inner_obj.handle_action(cls, outer_obj, 'contain',  'entered')
 
+    # TODO check aoe to see if players need to hear about visible container changes ^v
+
     @classmethod
     def remove_from(cls, outer_obj, inner_obj):
         Contains.delete().where(

--- a/server/tmserver/world.py
+++ b/server/tmserver/world.py
@@ -5,6 +5,7 @@ from slugify import slugify
 from .config import get_db
 from .errors import ClientException
 from .models import Contains, GameObject, Contains, Script
+from .util import strip_color_codes
 
 OBJECT_DENIED = 'You grab a hold of {} but no matter how hard you pull it stays rooted in place.'
 OBJECT_NOT_FOUND = 'You look in vain for {}.'
@@ -408,7 +409,7 @@ class GameWorld:
 
     @classmethod
     def derive_shortname(cls, owner_obj, *strings):
-        slugged = [slugify(s) for s in strings] + [owner_obj.user_account.username]
+        slugged = [slugify(strip_color_codes(s)) for s in strings] + [owner_obj.user_account.username]
         shortname = '-'.join(slugged)
         if GameObject.get_or_none(GameObject.shortname==shortname):
             obj_count = GameObject.select().where(GameObject.author==owner_obj.user_account).count()


### PR DESCRIPTION
fixes #67 

this PR:
- adds `get`, `drop`, `put`, `remove` commands
- adds at least one async test for each
- adds full unit tests for each
- introduces `util` module with code for stripping color codes / collapsing whitespace
- makes fuzzy matching ignore color codes