### PR TITLE
Implement REVISION handling on server

### DIFF
--- a/server/tmserver/core.py
+++ b/server/tmserver/core.py
@@ -5,7 +5,7 @@ import re
 
 import websockets as ws
 
-from .errors import ClientException, UserValidationError
+from .errors import ClientException, UserValidationError, RevisionException
 from .models import UserAccount, GameObject
 
 LOGIN_RE = re.compile(r'^LOGIN ([^:\n]+?):(.+)$')
@@ -63,7 +63,7 @@ class UserSession:
 
     def handle_revision(self, shortname, code, current_rev):
         return_payload = None
-        compilation_exception = None
+        revision_exception = None
         try:
             return_payload = self.game_world.handle_revision(
                 self.user_account.player_obj,
@@ -72,7 +72,7 @@ class UserSession:
                 current_rev)
         except RevisionException as e:
             return_payload = e.payload
-            revision_exception = e.msg
+            revision_exception = str(e)
 
         return return_payload, revision_exception
 
@@ -202,7 +202,7 @@ class GameServer:
         payload = self.parse_revision(message)
         return user_session.handle_revision(**payload)
 
-    def parse_revision(message):
+    def parse_revision(self, message):
         match = REVISION_RE.fullmatch(message)
         if match is None:
             raise ClientException('malformed revision payload: {}'.format(message))

--- a/server/tmserver/core.py
+++ b/server/tmserver/core.py
@@ -137,7 +137,7 @@ class GameServer:
                 if revision_exception:
                     # TODO consider something more specific than ERROR
                     await user_session.client_send('ERROR: {}'.revision_exception)
-                await user_session.client_send('REVISION {}'.format(json.dumps(revision_result)))
+                await user_session.client_send('OBJECT {}'.format(json.dumps(revision_result)))
             elif message.startswith('PING'):
                 await user_session.client_send('PONG')
             else:

--- a/server/tmserver/core.py
+++ b/server/tmserver/core.py
@@ -207,10 +207,13 @@ class GameServer:
         if match is None:
             raise ClientException('malformed revision payload: {}'.format(message))
         payload = match.groups()[0]
+
         try:
             payload = json.loads(payload)
         except Exception as e:
             raise ClientException('failed to parse revision payload: {}'.format(payload))
+
+        # TODO ensure it's a dict, raise otherwise
 
         for k in REVISION_KEYS:
             if payload.get(k) is None:

--- a/server/tmserver/core.py
+++ b/server/tmserver/core.py
@@ -113,6 +113,9 @@ class GameServer:
             elif message.startswith('COMMAND'):
                 self.handle_command(user_session, message)
                 await user_session.client_send('COMMAND OK')
+            elif message.startswith('REVISION'):
+                revision_result = self.handle_revision(user_session, message)
+                await user_session.client_send('REVISION {}'.format(json.dumps(revision_result)))
             elif message.startswith('PING'):
                 await user_session.client_send('PONG')
             else:
@@ -170,6 +173,10 @@ class GameServer:
         if match is None:
             raise ClientException('malformed registration message: {}'.format(message))
         return match.groups()
+
+    def handle_revision(self, user_session, message):
+        payload = self.parse_revision(message)
+        pass
 
     def start(self):
         self.logger.info('Starting up asyncio loop')

--- a/server/tmserver/errors.py
+++ b/server/tmserver/errors.py
@@ -1,3 +1,9 @@
+class RevisionException(Exception):
+    def __init__(*args, **kwargs):
+        payload = kwargs.pop('payload')
+        super().__init__(*args, **kwargs)
+        self.payload = payload
+
 class ClientException(Exception): pass
 class WitchException(Exception): pass
 class UserValidationError(Exception):

--- a/server/tmserver/errors.py
+++ b/server/tmserver/errors.py
@@ -1,5 +1,5 @@
 class RevisionException(Exception):
-    def __init__(*args, **kwargs):
+    def __init__(self, *args, **kwargs):
         payload = kwargs.pop('payload')
         super().__init__(*args, **kwargs)
         self.payload = payload

--- a/server/tmserver/migrations.py
+++ b/server/tmserver/migrations.py
@@ -44,7 +44,7 @@ def init_db():
     if 0 == GameObject.select().where(GameObject.shortname=='foyer').count():
         god_ua = UserAccount.get(UserAccount.username=='god')
         GameObject.create_scripted_object(
-            'room', god_ua, 'foyer',
+            god_ua, 'foyer', 'room',
             {'name': 'Foyer',
              'description': "A waiting room. Magazines in every language from every decade litter dusty end tables sitting between overstuffed armchairs." })
 

--- a/server/tmserver/models.py
+++ b/server/tmserver/models.py
@@ -143,6 +143,7 @@ class Permission(BaseModel):
 
 class GameObject(BaseModel, ScriptedObjectMixin):
     author = pw.ForeignKeyField(UserAccount)
+    # TODO index?
     shortname = pw.CharField(null=False, unique=True)
     script_revision = pw.ForeignKeyField(ScriptRevision, null=True)
     is_player_obj = pw.BooleanField(default=False)

--- a/server/tmserver/models.py
+++ b/server/tmserver/models.py
@@ -16,7 +16,7 @@ BAD_USERNAME_CHARS_RE = re.compile(r'[\:\'";%]')
 MIN_PASSWORD_LEN = 12
 
 class BaseModel(Model):
-    created_at = pw.DateTimeField(default=datetime.utcnow())
+    created_at = pw.DateTimeField(default=datetime.utcnow)
     class Meta:
         database = config.get_db()
 
@@ -206,6 +206,18 @@ class GameObject(BaseModel, ScriptedObjectMixin):
         if self.is_player_obj:
             return self.author
         return None
+
+    @property
+    def latest_script_rev(self):
+        # TODO this barfs for objects without script revisions. ultimately
+        # objects probably shouldn't lack script revisions so i'll let it blow
+        # up as a reminder.
+        current_rev = self.script_revision
+        return ScriptRevision\
+            .select()\
+            .where(ScriptRevision.script==current_rev.script)\
+            .order_by(ScriptRevision.created_at.desc())\
+            .limit(1)[0]
 
     def set_perm(self, perm, setting):
         """Given a perm defined in Permission and either 'owner' or 'world',

--- a/server/tmserver/models.py
+++ b/server/tmserver/models.py
@@ -86,13 +86,13 @@ def on_user_account_create(cls, instance, created):
 
     with config.get_db().atomic():
         player = GameObject.create_scripted_object(
-            'player', instance, instance.username,
+            instance, instance.username, 'player',
             {'name': instance.username,
             'description': 'a gaseous cloud'})
         player.is_player_obj = True
         player.save()
         sanctum = GameObject.create_scripted_object(
-            'room', instance, '{}-sanctum'.format(instance.username),
+            instance, '{}-sanctum'.format(instance.username), 'room',
             dict(name="{}'s Sanctum".format(instance.username),
                  description="""This is your private space. Only you (and gods)
                  can enter here. Any new rooms you create will be attached to

--- a/server/tmserver/models.py
+++ b/server/tmserver/models.py
@@ -152,13 +152,16 @@ class GameObject(BaseModel, ScriptedObjectMixin):
     perms = pw.ForeignKeyField(Permission, backref='obj', null=True)
 
     @classmethod
-    def create_scripted_object(cls, obj_type, author, shortname, format_dict=None):
+    def create_scripted_object(cls, author, shortname, obj_type='item', format_dict=None):
         """This function does the necessary shenanigans to create a
         script/scriptrev/obj. It creates them all in the DB and returns the
         GameObject."""
 
         if format_dict is None:
-            format_dict = {}
+            format_dict = {
+                'name': 'an object',
+                'description': 'a perfect gray sphere'
+            }
 
         if 'description' in format_dict:
             format_dict['description'] = collapse_whitespace(format_dict['description'])

--- a/server/tmserver/models.py
+++ b/server/tmserver/models.py
@@ -140,6 +140,16 @@ class Permission(BaseModel):
     carry = pw.IntegerField(default=WORLD)
     execute = pw.IntegerField(default=WORLD)
 
+    def _enum_to_str(self, perm):
+        return 'world' if perm == self.WORLD else 'owner'
+
+    def as_dict(self):
+        return dict(
+            read=self._enum_to_str(self.read),
+            write=self._enum_to_str(self.write),
+            carry=self._enum_to_str(self.carry),
+            execute=self._enum_to_str(self.execute))
+
 
 class GameObject(BaseModel, ScriptedObjectMixin):
     author = pw.ForeignKeyField(UserAccount)

--- a/server/tmserver/scripting.py
+++ b/server/tmserver/scripting.py
@@ -202,9 +202,13 @@ class ScriptedObjectMixin:
     def _ensure_data(self, data_mapping):
         """Given the default values for some gameobject's script, initialize
         this object's data column to those defaults. Saves the instance."""
-        if data_mapping == {} or self.data != {}:
+        if data_mapping == {}:
             return
-        self.data = data_mapping
+
+        for k,v in data_mapping.items():
+            if k not in self.data:
+                self.data[k] = v
+
         self.save()
 
     def _ensure_world(self, game_world):

--- a/server/tmserver/scripting.py
+++ b/server/tmserver/scripting.py
@@ -132,7 +132,7 @@ class ScriptedObjectMixin:
                 # latest_script_rev to like get_latested_script_rev() or
                 # something.
                 current_rev = self.script_revision
-                latested_rev = self.latest_script_rev
+                latest_rev = self.latest_script_rev
                 if latest_rev.id != current_rev.id:
                     try:
                         self.script_revision = latest_rev

--- a/server/tmserver/tests/async_test.py
+++ b/server/tmserver/tests/async_test.py
@@ -753,7 +753,8 @@ async def test_revision(event_loop, mock_logger, client):
     new_code = """
     (witch "cigar"
       (has {"name" "A fresh cigar"
-            "description" "An untouched black and mild with a wood tip"})
+            "description" "An untouched black and mild with a wood tip"
+            "smoked" False})
       (hears "smoke"
         (says "i'm cancer")))""".rstrip().lstrip()
 
@@ -765,13 +766,22 @@ async def test_revision(event_loop, mock_logger, client):
     await client.send('REVISION {}'.format(json.dumps(revision_payload)))
 
     msg = await client.recv()
-    assert msg.startswith('REVISION')
+    assert msg.startswith('OBJECT')
     payload = json.loads(msg.split(' ', maxsplit=1)[1])
 
     latest_rev = cigar.latest_script_rev
 
     assert payload == dict(
         shortname='vilmibm/a-fresh-cigar',
+        data=dict(
+            name='A fresh cigar',
+            description='An untouched black and mild with a wood tip',
+            smoked=False),
+        permissions=dict(
+            read='world',
+            write='owner',
+            carry='world',
+            execute='world'),
         errors=[],
         code=new_code,
         current_rev=latest_rev.id)

--- a/server/tmserver/tests/async_test.py
+++ b/server/tmserver/tests/async_test.py
@@ -619,9 +619,6 @@ async def test_handle_drop(event_loop, mock_logger, client):
 
     await client.close()
 
-# TODO unit test all of the inventory stuff until writing async tests is easier
-# (aside from a single smoke test per remaining command)
-
 @pytest.mark.asyncio
 async def test_handle_put(event_loop, mock_logger, client):
     god = UserAccount.get(UserAccount.username=='god')

--- a/server/tmserver/tests/async_test.py
+++ b/server/tmserver/tests/async_test.py
@@ -221,7 +221,10 @@ async def test_look(event_loop, mock_logger, client):
         'item', vil, 'cigar', {
             'name': 'cigar',
             'description': 'a fancy cigar ready for lighting'})
-    phone = GameObject.create(author=vil, shortname='smartphone')
+    phone = GameObject.create_scripted_object(
+        'item', vil, 'smartphone', dict(
+            name='smartphone',
+            description='the devil'))
     app = GameObject.create_scripted_object(
         'item', vil, 'kwam', {
             'name': 'Kwam',

--- a/server/tmserver/tests/async_test.py
+++ b/server/tmserver/tests/async_test.py
@@ -218,15 +218,15 @@ async def test_look(event_loop, mock_logger, client):
     snoozy_client = await websockets.connect('ws://localhost:5555', loop=event_loop)
     await setup_user(snoozy_client, 'snoozy')
     cigar = GameObject.create_scripted_object(
-        'item', vil, 'cigar', {
+        vil, 'cigar', 'item', {
             'name': 'cigar',
             'description': 'a fancy cigar ready for lighting'})
     phone = GameObject.create_scripted_object(
-        'item', vil, 'smartphone', dict(
+        vil, 'smartphone', 'item', dict(
             name='smartphone',
             description='the devil'))
     app = GameObject.create_scripted_object(
-        'item', vil, 'kwam', {
+        vil, 'kwam', 'item', {
             'name': 'Kwam',
             'description': 'A smartphone application for KWAM'})
     foyer = GameObject.get(GameObject.shortname=='foyer')
@@ -256,43 +256,43 @@ async def test_client_state(event_loop, mock_logger, client):
     god = UserAccount.get(UserAccount.username=='god')
 
     room = GameObject.create_scripted_object(
-        'room', god, 'ten-forward', dict(
+        god, 'ten-forward', 'room', dict(
             name='ten forward',
             description='the bar lounge of the starship enterprise.'))
     quadchess = GameObject.create_scripted_object(
-        'item', god, 'quadchess', dict(
+        god, 'quadchess', 'item', dict(
             name='quadchess',
             description='a chess game with four decks'))
     chess_piece = GameObject.create_scripted_object(
-        'item', god, 'chess-piece', dict(
+        god, 'chess-piece', 'item', dict(
             name='chess piece',
             description='a chess piece. Looks like a bishop.'))
     drink = GameObject.create_scripted_object(
-        'item', god, 'weird-drink', dict(
+        god, 'weird-drink', 'item', dict(
             name='weird drink',
             description='an in-house invention of Guinan. It is purple and fizzes ominously.'))
     tricorder = GameObject.create_scripted_object(
-        'item', god, 'tricorder', dict(
+        god, 'tricorder', 'item', dict(
             name='tricorder',
             description='looks like someone left their tricorder here.'))
     medical_app = GameObject.create_scripted_object(
-        'item', god, 'medical-program', dict(
+        god, 'medical-program', 'item', dict(
             name='medical program',
             description='you can use this to scan or call up data about a patient.'))
     patient_file = GameObject.create_scripted_object(
-        'item', god, 'patient-file', dict(
+        god, 'patient-file', 'item', dict(
             name='patient file',
             description='a scan of Lt Barclay'))
     phase_analyzer_app = GameObject.create_scripted_object(
-        'item', god, 'phase-analyzer-program', dict(
+        god, 'phase-analyzer-program', 'item', dict(
             name='phase analyzer program',
             description='you can use this to scan for phase shift anomalies'))
     music_app = GameObject.create_scripted_object(
-        'item', god, 'media-app', dict(
+        god, 'media-app', 'item', dict(
             name='media app',
             description='this program turns your tricorder into a jukebox'))
     klingon_opera = GameObject.create_scripted_object(
-        'item', god, 'klingon-opera-music', dict(
+        god, 'klingon-opera-music', 'item', dict(
             name='klingon opera music',
             description='a recording of a klingon opera'))
     GameWorld.put_into(room, quadchess)
@@ -306,11 +306,11 @@ async def test_client_state(event_loop, mock_logger, client):
     GameWorld.put_into(music_app, klingon_opera)
 
     GameObject.create_scripted_object(
-        'room', god, 'jeffries-tube-god', dict(
+        god, 'jeffries-tube-god', 'room', dict(
             name='Jeffries Tube',
             description='A cramped little space used for maintenance.'))
     GameObject.create_scripted_object(
-        'room', god, 'replicator-room-god', dict(
+        god, 'replicator-room-god', 'room', dict(
             name='Replicator Room',
             description="Little more than a closet, you can use this room to interact with the replicator in case you don't want to make an order a the bar."))
 
@@ -544,7 +544,7 @@ async def test_handle_get(event_loop, mock_logger, client):
     foyer = GameObject.get(GameObject.shortname == 'foyer')
 
     cigar = GameObject.create_scripted_object(
-        'item', vil, 'vilmibm/a-fresh-cigar', dict(
+        vil, 'vilmibm/a-fresh-cigar', 'item', dict(
             name='A fresh cigar',
             description='smoke it if you want'))
 
@@ -571,7 +571,7 @@ async def test_handle_get_denied(event_loop, mock_logger, client):
     god = UserAccount.get(UserAccount.username=='god')
     foyer = GameObject.get(GameObject.shortname=='foyer')
     phaser = GameObject.create_scripted_object(
-        'item', god, 'phaser-god', dict(
+        god, 'phaser-god', 'item', dict(
             name='a phaser',
             description='watch where u point it'))
 
@@ -592,7 +592,7 @@ async def test_handle_drop(event_loop, mock_logger, client):
     god = UserAccount.get(UserAccount.username=='god')
     foyer = GameObject.get(GameObject.shortname=='foyer')
     phaser = GameObject.create_scripted_object(
-        'item', god, 'phaser-god', dict(
+        god, 'phaser-god', 'item', dict(
             name='a phaser',
             description='watch where u point it'))
 
@@ -627,11 +627,11 @@ async def test_handle_put(event_loop, mock_logger, client):
     god = UserAccount.get(UserAccount.username=='god')
     foyer = GameObject.get(GameObject.shortname=='foyer')
     phaser = GameObject.create_scripted_object(
-        'item', god, 'phaser-god', dict(
+        god, 'phaser-god', 'item', dict(
             name='a phaser',
             description='watch where u point it'))
     space_chest = GameObject.create_scripted_object(
-        'item', god, 'space-chest-god', dict(
+        god, 'space-chest-god', 'item', dict(
             name='Fancy Space Chest',
             description="It's like a fantasy chest but palette swapped."))
 
@@ -658,11 +658,11 @@ async def test_handle_remove(event_loop, mock_logger, client):
     god = UserAccount.get(UserAccount.username=='god')
     foyer = GameObject.get(GameObject.shortname=='foyer')
     phaser = GameObject.create_scripted_object(
-        'item', god, 'phaser-god', dict(
+        god, 'phaser-god', 'item', dict(
             name='a phaser',
             description='watch where u point it'))
     space_chest = GameObject.create_scripted_object(
-        'item', god, 'space-chest-god', dict(
+        god, 'space-chest-god', 'item', dict(
             name='Fancy Space Chest',
             description="It's like a fantasy chest but palette swapped."))
 

--- a/server/tmserver/tests/async_test.py
+++ b/server/tmserver/tests/async_test.py
@@ -727,3 +727,6 @@ async def test_create_twoway_exit_via_world_perms(event_loop, mock_logger, clien
     assert vil.player_obj in foyer.contains
 
     await client.close()
+
+
+# TODO REVISION golden path test

--- a/server/tmserver/tests/contain_test.py
+++ b/server/tmserver/tests/contain_test.py
@@ -9,13 +9,14 @@ class ContainTest(TildemushTestCase):
         self.vil = UserAccount.create(
             username='vilmibm',
             password='foobarbazquux')
-        self.room = GameObject.create(
+        self.room = GameObject.create_scripted_object(
             author=self.vil,
-            shortname='foul-foyer',)
-        self.phone = GameObject.create(
+            shortname='foul-foyer',
+            obj_type='room')
+        self.phone = GameObject.create_scripted_object(
             author=self.vil,
             shortname='pixel-2')
-        self.app = GameObject.create(
+        self.app = GameObject.create_scripted_object(
             author=self.vil,
             shortname='signal')
 
@@ -28,15 +29,16 @@ class ContainTest(TildemushTestCase):
 
     def test_area_of_effect(self):
         player_obj = self.vil.player_obj
-        cigar = GameObject.create(
+        cigar = GameObject.create_scripted_object(
             author=self.vil,
             shortname='black-and-mild')
-        rug = GameObject.create(
+        rug = GameObject.create_scripted_object(
             author=self.vil,
             shortname='rug')
-        ship = GameObject.create(
+        ship = GameObject.create_scripted_object(
             author=self.vil,
-            shortname='voyager')
+            shortname='voyager',
+            obj_type='room')
 
         Contains.create(
             outer_obj=self.room,
@@ -89,15 +91,16 @@ class ContainTest(TildemushTestCase):
 
     def test_all_active_objects(self):
         player_obj = self.vil.player_obj
-        cigar = GameObject.create(
+        cigar = GameObject.create_scripted_object(
             author=self.vil,
             shortname='black-and-mild')
-        rug = GameObject.create(
+        rug = GameObject.create_scripted_object(
             author=self.vil,
             shortname='rug')
-        ship = GameObject.create(
+        ship = GameObject.create_scripted_object(
             author=self.vil,
-            shortname='voyager')
+            shortname='voyager',
+            obj_type='room')
 
         GameWorld.put_into(self.room, player_obj)
         GameWorld.put_into(self.phone, self.app)

--- a/server/tmserver/tests/game_object_test.py
+++ b/server/tmserver/tests/game_object_test.py
@@ -90,13 +90,6 @@ class GameObjectDataTest(TildemushTestCase):
 
         assert not save_m.called
 
-    def test_ensure_data_ignores_populated_data_mapping(self):
-        self.snoozy.data = {'stuff': 'here'}
-        self.snoozy.save()
-        with mock.patch('tmserver.models.GameObject.save') as save_m:
-            self.snoozy._ensure_data({'aw':'yis'})
-        assert not save_m.called
-
     def test_ensure_data(self):
         some_data = {
             'stuff': 'here',
@@ -122,6 +115,24 @@ class GameObjectDataTest(TildemushTestCase):
         self.snoozy._ensure_data(some_data)
         self.snoozy.set_data('num_pets', self.snoozy.get_data('num_pets') + 1)
         assert 1 == GameObject.get_by_id(self.snoozy.id).get_data('num_pets')
+
+    def test_handles_new_default_keys(self):
+        some_data = {
+            'smoked': False,
+            'length': 4
+        }
+        self.snoozy._ensure_data(some_data)
+        assert False == self.snoozy.get_data('smoked')
+        assert 4 == self.snoozy.get_data('length')
+        new_data = {
+            'smoked': True,
+            'length': 20,
+            'wrapper': 'brown',
+        }
+        self.snoozy._ensure_data(new_data)
+        assert False == self.snoozy.get_data('smoked')
+        assert 4 == self.snoozy.get_data('length')
+        assert 'brown' == self.snoozy.get_data('wrapper')
 
 
 def GameObjectComparisonTest(self):

--- a/server/tmserver/tests/game_object_test.py
+++ b/server/tmserver/tests/game_object_test.py
@@ -16,13 +16,13 @@ class FuzzyMatchTest(TildemushTestCase):
             password='foobarbazquux')
 
         self.phaser = GameObject.create_scripted_object(
-            'item', self.vil, 'phaser-vilmibm-666', dict(
+            self.vil, 'phaser-vilmibm-666', 'item', dict(
                 name='Federation Phaser',
                 description='Looks like a remote control, but is far deadlier. You should probably leave it set for stun.'))
 
     def test_ignores_color_codes(self):
         rainbow = GameObject.create_scripted_object(
-            'item', self.vil, 'contrived-example-vilmibm', dict(
+            self.vil, 'contrived-example-vilmibm', 'item', dict(
                 name='a {red}r{orange}a{yellow}i{green}n{blue}b{indigo}o{violet}w{/}',
                 description="all the way across the sky."))
         assert rainbow.fuzzy_match('rainbow')
@@ -62,7 +62,7 @@ class CreateScriptedObjectTest(TildemushTestCase):
 
     def test_data_initialized(self):
         banana = GameObject.create_scripted_object(
-            'item', self.vil, 'banana-vilmibm', dict(
+            self.vil, 'banana-vilmibm', 'item', dict(
                 name='A Banana',
                 description='Still green.'))
         assert banana.data == dict(

--- a/server/tmserver/tests/inventory_test.py
+++ b/server/tmserver/tests/inventory_test.py
@@ -16,11 +16,11 @@ class InventoryTestCase(TildemushTestCase):
             password='foobarbazquux')
 
         can = GameObject.create_scripted_object(
-            'item', god, 'can-god', dict(
+            god, 'can-god', 'item', dict(
                 name='A Rusted Tin Can',
                 description='The label has been torn off. A patch of adhesive is still a little sticky, though the metal is all rusted over. Something about it is unsettling.'))
         bag = GameObject.create_scripted_object(
-            'item', god, 'bag-god', dict(
+            god, 'bag-god', 'item', dict(
                 name='A Garbage Bag',
                 description="It's just a garbage bag. The black, glossy kind. You wonder how much stuff you could fit in there."))
 
@@ -57,7 +57,7 @@ class GetTest(InventoryTestCase):
 
     def test_ambiguity(self, mock_hears):
         shiny_can = GameObject.create_scripted_object(
-            'item', self.god, 'can-shiny-god', dict(
+            self.god, 'can-shiny-god', 'item', dict(
                 name='A New, Shiny Tin Can',
                 description="A new can. Not even adhesive on this. You can see yourself in its reflection but you're all ripply."))
         GameWorld.put_into(self.foyer, shiny_can)
@@ -82,7 +82,7 @@ class DropTest(InventoryTestCase):
 
     def test_ambiguity(self, mock_hears):
         shiny_can = GameObject.create_scripted_object(
-            'item', self.god, 'can-shiny-god', dict(
+            self.god, 'can-shiny-god', 'item', dict(
                 name='A New, Shiny Tin Can',
                 description="A new can. Not even adhesive on this. You can see yourself in its reflection but you're all ripply."))
         GameWorld.put_into(self.foyer, shiny_can)

--- a/server/tmserver/tests/move_test.py
+++ b/server/tmserver/tests/move_test.py
@@ -13,13 +13,13 @@ class MoveTest(TildemushTestCase):
             password='foobarbazquux')
         user_session = UserSession(None, GameWorld, mock.Mock())
         user_session.associate(self.same)
-        self.pond = GameObject.create(
+        self.pond = GameObject.create_scripted_object(
             author=self.same,
             shortname='pond',)
-        self.cabin = GameObject.create(
+        self.cabin = GameObject.create_scripted_object(
             author=self.same,
             shortname='cabin',)
-        self.frog = GameObject.create(
+        self.frog = GameObject.create_scripted_object(
             author=self.same,
             shortname='dumb frog')
 

--- a/server/tmserver/tests/perm_test.py
+++ b/server/tmserver/tests/perm_test.py
@@ -13,11 +13,11 @@ class PermissionTest(TildemushTestCase):
         self.vil = vil_ua.player_obj
         self.zechs = zechs_ua.player_obj
         self.tofu = GameObject.create_scripted_object(
-            'item', vil_ua, 'tofu-vilmibm', dict(
+            vil_ua, 'tofu-vilmibm', 'item', dict(
                 name='a block of tofu',
                 description='squishy and cubic'))
         self.tallgeese = GameObject.create_scripted_object(
-            'item', zechs_ua, 'tallgeese-zechs', dict(
+            zechs_ua, 'tallgeese-zechs', 'item', dict(
                 name='a large mobile suit',
                 description='tall and fast'))
 

--- a/server/tmserver/tests/revision_test.py
+++ b/server/tmserver/tests/revision_test.py
@@ -103,6 +103,11 @@ class GameWorldRevisionHandlingTest(TildemushTestCase):
 
         assert cm.exception.payload == {
             'shortname': 'someone/book',
+            'data': {'description': 'Electronic Life by Michael Crichton', 'name':'Book'},
+            'permissions': {'carry': 'world',
+                            'execute': 'world',
+                            'read': 'world',
+                            'write': 'owner'},
             'current_rev': self.book.script_revision.id,
             'code': self.book.script_revision.code}
 
@@ -119,6 +124,11 @@ class GameWorldRevisionHandlingTest(TildemushTestCase):
 
         assert cm.exception.payload == {
             'shortname': 'vilmibm/snoozy',
+            'data': {'description': 'just a horse', 'name':'snoozy'},
+            'permissions': {'carry': 'world',
+                            'execute': 'world',
+                            'read': 'world',
+                            'write': 'owner'},
             'current_rev': self.snoozy.script_revision.id,
             'code': self.snoozy.script_revision.code}
 
@@ -135,6 +145,11 @@ class GameWorldRevisionHandlingTest(TildemushTestCase):
 
         assert cm.exception.payload == {
             'shortname': 'vilmibm/snoozy',
+            'data': {'description': 'just a horse', 'name':'snoozy'},
+            'permissions': {'carry': 'world',
+                            'execute': 'world',
+                            'read': 'world',
+                            'write': 'owner'},
             'current_rev': self.snoozy.script_revision.id,
             'code': self.snoozy.script_revision.code}
 
@@ -148,6 +163,11 @@ class GameWorldRevisionHandlingTest(TildemushTestCase):
         latest_rev = self.snoozy.latest_script_rev
         expected = {
             'shortname': 'vilmibm/snoozy',
+            'data': {'description': 'just a horse', 'name':'snoozy'},
+            'permissions': {'carry': 'world',
+                            'execute': 'world',
+                            'read': 'world',
+                            'write': 'owner'},
             'current_rev': latest_rev.id,
             'code': latest_rev.code,
             'errors': [";_; There is a problem with your witch script: name 'lol' is not defined"]}
@@ -173,6 +193,11 @@ class GameWorldRevisionHandlingTest(TildemushTestCase):
         latest_rev = self.snoozy.latest_script_rev
         expected = {
             'shortname': 'vilmibm/snoozy',
+            'data': {'description': 'just a horse', 'name':'snoozy'},
+            'permissions': {'carry': 'world',
+                            'execute': 'world',
+                            'read': 'world',
+                            'write': 'owner'},
             'current_rev': latest_rev.id,
             'code': latest_rev.code,
             'errors': []}

--- a/server/tmserver/tests/revision_test.py
+++ b/server/tmserver/tests/revision_test.py
@@ -82,11 +82,11 @@ class GameWorldRevisionHandlingTest(TildemushTestCase):
             username='someone',
             password='foobarbazquux')
         self.snoozy = GameObject.create_scripted_object(
-            'item', self.vil, 'vilmibm/snoozy', dict(
+            self.vil, 'vilmibm/snoozy', 'item', dict(
                 name='snoozy',
                 description='just a horse'))
         self.book = GameObject.create_scripted_object(
-            'item', self.someone, 'someone/book', dict(
+            self.someone, 'someone/book', 'item', dict(
                 name='Book',
                 description='Electronic Life by Michael Crichton'))
 
@@ -189,7 +189,7 @@ class GameObjectRevisionUpdateTest(TildemushTestCase):
             username='vilmibm',
             password='foobarbazquux')
         self.snoozy = GameObject.create_scripted_object(
-            'item', self.vil, 'vilmibm/snoozy', dict(
+            self.vil, 'vilmibm/snoozy', 'item', dict(
                 name='snoozy',
                 description='just a horse'))
 

--- a/server/tmserver/tests/revision_test.py
+++ b/server/tmserver/tests/revision_test.py
@@ -1,0 +1,58 @@
+# TODO unit test parse_revision
+# TODO unit test handle_revision
+# TODO unit test UserSession.handle_revision
+# TODO unit test GameWorld.handle_revision
+# TODO unit test revision update handling in GameObject.engine()
+
+from .tm_test_case import TildemushTestCase
+
+class GameServerRevisionHandlingTest(TildemushTestCase):
+
+    def test_require_auth(self):
+        pass
+
+    def test_malformed_payload(self):
+        pass
+
+    def test_missing_keys(self):
+        pass
+
+    def test_bad_json(self):
+        pass
+
+    def test_chill(self):
+        pass
+
+class UserSessionRevisionHandlingTest(TildemushTestCase):
+    def test_revision_error(self):
+        pass
+
+    def test_chill(self):
+        pass
+
+class GameWorldRevisionHandlingTest(TildemushTestCase):
+    def test_perm_denied(self):
+        pass
+
+    def test_revision_mismatch(self):
+        pass
+
+    def test_no_change(self):
+        pass
+
+    def test_witch_error(self):
+        pass
+
+    def test_chill(self):
+        pass
+
+class GameObjectRevisionUpdateTest(TildemushTestCase):
+    def test_already_on_latest_rev(self):
+        pass
+
+    def test_witch_error(self):
+        # TODO the behavior for this is undefined
+        pass
+
+    def test_chill(self):
+        pass

--- a/server/tmserver/world.py
+++ b/server/tmserver/world.py
@@ -437,7 +437,7 @@ class GameWorld:
     def create_item(cls, owner_obj, name, additional_args):
         shortname = cls.derive_shortname(owner_obj, name)
         item = GameObject.create_scripted_object(
-            'item', owner_obj.user_account, shortname, {
+            owner_obj.user_account, shortname, 'item', {
             'name': name,
             'description': additional_args})
         cls.put_into(owner_obj, item)
@@ -448,7 +448,7 @@ class GameWorld:
     def create_room(cls, owner_obj, name, additional_args):
         shortname = cls.derive_shortname(owner_obj, name)
         room = GameObject.create_scripted_object(
-            'room', owner_obj.user_account, shortname, {
+            owner_obj.user_account, shortname, 'room', {
             'name': name,
             'description': additional_args})
 
@@ -486,7 +486,7 @@ class GameWorld:
         # make the here_exit
         shortname = cls.derive_shortname(owner_obj, name)
         here_exit = GameObject.create_scripted_object(
-            'exit', owner_obj.user_account, shortname, {
+            owner_obj.user_account, shortname, 'exit', {
             'name': name,
             'description': description,
             'target_room_name': target_room.shortname})
@@ -508,7 +508,7 @@ class GameWorld:
            or owner_obj.can_write(target_room):
             shortname = cls.derive_shortname(owner_obj, name, 'reverse')
             there_exit = GameObject.create_scripted_object(
-                'exit', owner_obj.user_account, shortname, {
+                owner_obj.user_account, shortname, 'exit', {
                 'name': name,
                 'description': description,
                 'target_room_name': current_room.shortname})
@@ -532,7 +532,7 @@ class GameWorld:
         description = 'Touching this stone will transport you to'.format(target.name)
         shortname = cls.derive_shortname(owner_obj, name)
         return GameObject.create_scripted_object(
-            'portkey', owner_obj.user_account, shortname, {
+            owner_obj.user_account, shortname, 'portkey', {
             'name': name,
             'description': description,
             'target_room_name': target.shortname})

--- a/server/tmserver/world.py
+++ b/server/tmserver/world.py
@@ -738,6 +738,10 @@ class GameWorld:
             # TODO this is going to create sadness; should be handled and user
             # gently told
             obj = GameObject.get(GameObject.shortname==shortname)
+
+            result['data'] = obj.data
+            result['permissions'] = obj.perms.as_dict()
+
             error = None
             if not (owner_obj.can_write(obj) or owner_obj.user_account == obj.author):
                 error = 'Tried to edit illegal object'

--- a/server/tmserver/world.py
+++ b/server/tmserver/world.py
@@ -3,7 +3,7 @@ import re
 from slugify import slugify
 
 from .config import get_db
-from .errors import RevisionException, WitchException
+from .errors import RevisionException, WitchException, ClientException
 from .models import Contains, GameObject, Script, ScriptRevision, Permission
 from .util import strip_color_codes
 


### PR DESCRIPTION
This PR adds a new payload handler called `REVISION`.

Part of #82 

It:
 - takes a new pile of WITCH for an object
 - saves a new revision
 - reports on compilation errors
 - lets gameobjects in RAM notice these new revisions lazily and try to use them, only upgrading themselves if the WITCH compiles ok
 - eventually responds to any REVISION payload with an OBJECT payload

TODO:

- [x] `ensure_data` should pick up new default data keys 