### PR TITLE
/edit handler

### DIFF
--- a/server/tmserver/core.py
+++ b/server/tmserver/core.py
@@ -52,6 +52,12 @@ class UserSession:
             self.client_send('STATE {}'.format(json.dumps(client_state))),
             loop=self.loop)
 
+    def send_object_state(self, object_state):
+        asyncio.ensure_future(
+            self.client_send('OBJECT {}'.format(json.dumps(object_state))),
+            loop=self.loop
+        )
+
     async def client_send(self, message):
         await self.websocket.send(message)
 
@@ -137,7 +143,7 @@ class GameServer:
                 if revision_exception:
                     # TODO consider something more specific than ERROR
                     await user_session.client_send('ERROR: {}'.revision_exception)
-                await user_session.client_send('OBJECT {}'.format(json.dumps(revision_result)))
+                user_session.send_object_state(revision_result)
             elif message.startswith('PING'):
                 await user_session.client_send('PONG')
             else:

--- a/server/tmserver/models.py
+++ b/server/tmserver/models.py
@@ -334,6 +334,9 @@ def on_game_object_create(cls, instance, created):
     instance.perms = Permission.create()
     instance.save()
 
+class Editing(BaseModel):
+    user_account = pw.ForeignKeyField(UserAccount)
+    game_obj = pw.ForeignKeyField(GameObject)
 
 class Contains(BaseModel):
     outer_obj = pw.ForeignKeyField(GameObject)
@@ -346,4 +349,4 @@ class Log(BaseModel):
     raw = pw.CharField()
 
 
-MODELS = [UserAccount, Log, GameObject, Contains, Script, ScriptRevision, Permission]
+MODELS = [UserAccount, Log, GameObject, Contains, Script, ScriptRevision, Permission, Editing]

--- a/server/tmserver/world.py
+++ b/server/tmserver/world.py
@@ -724,16 +724,6 @@ class GameWorld:
         result = {
             'shortname': shortname,
         }
-        # if an error prevents us from saving anything, we want to just return
-        # the current state to the user but also communicate what happened. for
-        # now i'm thinking that results in two things being sent to the client:
-        # the REVISION payload for the unchanged object and an REVERROR message
-        # with the relevant exception that can be handled specially by the
-        # client.
-        #
-        # if we are clear to save and do but then there's a WitchException, we
-        # want to include that error in the payload we send as REVISION so it
-        # can be shown in the EDIT pane.
         with get_db().atomic():
             # TODO this is going to create sadness; should be handled and user
             # gently told


### PR DESCRIPTION
Part of #82 

This completes the first round of implementation for the /edit command as far as the server is concerned; we still need to get it hooked up to the client.

This PR:

- Accepts `/edit shortname`
- Locks/unlocks objects accordingly in a new table
- Sends the initial OBJECT payload to the client