### PR TITLE
Transitive commands

### DIFF
--- a/server/tmserver/tests/arg_parse_test.py
+++ b/server/tmserver/tests/arg_parse_test.py
@@ -53,4 +53,3 @@ class ArgParseTest(TildemushUnitTestCase):
             ("hi there how'", ['hi', 'there', 'how']),
         ]
         for i in inputs: assert i[1] == split_args(i[0])
-

--- a/server/tmserver/tests/arg_parse_test.py
+++ b/server/tmserver/tests/arg_parse_test.py
@@ -1,0 +1,56 @@
+from .tm_test_case import TildemushUnitTestCase
+from ..util import split_args
+
+
+class ArgParseTest(TildemushUnitTestCase):
+    def test_single_quotes(self):
+        inputs = [
+            ("'hi there' how are you", ['hi there', 'how', 'are', 'you']),
+            ("hi 'there how' are you", ['hi', 'there how', 'are', 'you']),
+            ("hi 'there how' 'are you' today", ['hi', 'there how', 'are you', 'today']),
+            ("'hi there' 'how are'", ['hi there', 'how are'])
+        ]
+        for i in inputs: assert i[1] == split_args(i[0])
+
+    def test_double_quotes(self):
+        inputs = [
+            ('"hi there" how are you', ['hi there', 'how', 'are', 'you']),
+            ('hi "there how" are you', ['hi', 'there how', 'are', 'you']),
+            ('hi "there how" "are you" today', ['hi', 'there how', 'are you', 'today']),
+            ('"hi there" "how are"', ['hi there', 'how are'])
+        ]
+        for i in inputs: assert i[1] == split_args(i[0])
+
+    def test_no_quotes(self):
+        inputs = [
+            ('hi', ['hi']),
+            ('hi there', ['hi', 'there']),
+            ('hi there how', ['hi', 'there', 'how']),
+        ]
+        for i in inputs: assert i[1] == split_args(i[0])
+
+    def test_extra_whitespace(self):
+        inputs = [
+            ('   hi', ['hi']),
+            ('   hi    ', ['hi']),
+            ('hi    ', ['hi']),
+            ('hi    there', ['hi', 'there']),
+            ('hi    there      ', ['hi', 'there']),
+            ('hi   "there how    " are you', ['hi', 'there how', 'are', 'you'])
+        ]
+        for i in inputs: assert i[1] == split_args(i[0])
+
+    def test_mix(self):
+        i = 'hi "is this vil\'s garbage" \'how are you\' i am fine'
+        o = ['hi', "is this vil's garbage", 'how are you', 'i', 'am', 'fine']
+        assert o == split_args(i)
+
+    def test_unbalanced_quotes(self):
+        inputs = [
+            ('"hi there how', ['hi', 'there', 'how']),
+            ('hi there how"', ['hi', 'there', 'how']),
+            ("'hi there how", ['hi', 'there', 'how']),
+            ("hi there how'", ['hi', 'there', 'how']),
+        ]
+        for i in inputs: assert i[1] == split_args(i[0])
+

--- a/server/tmserver/tests/async_test.py
+++ b/server/tmserver/tests/async_test.py
@@ -963,9 +963,8 @@ async def test_transitive_command(event_loop, mock_logger, client):
     await client.send('COMMAND touch contrivance')
     msg = await client.recv()
     assert msg == 'COMMAND OK'
-    msg = await client.recv()
-    assert msg == 'cat says, "purr"'
-    msg = await client.recv()
-    assert msg == 'lemongrab says, "UNACCEPTABLE"'
+    msg1 = await client.recv()
+    msg2 = await client.recv()
+    assert {msg1, msg2} == {'cat says, "purr"', 'lemongrab says, "UNACCEPTABLE"'}
 
     await client.close()

--- a/server/tmserver/tests/async_test.py
+++ b/server/tmserver/tests/async_test.py
@@ -889,5 +889,83 @@ async def test_edit(event_loop, mock_logger, client):
     await snoozy_client.close()
     await client.close()
 
-
 # TODO witch exception when saving revision
+
+@pytest.mark.asyncio
+async def test_transitive_command(event_loop, mock_logger, client):
+    await setup_user(client, 'vilmibm')
+    vil = UserAccount.get(UserAccount.username=='vilmibm')
+
+    ### create an object to send transitive commands to
+    await client.send('COMMAND create item "lemongrab" a high strung lemon man')
+    msg = await client.recv()
+    assert msg == 'COMMAND OK'
+    msg = await client.recv()
+    assert msg.startswith('STATE')
+    msg = await client.recv()
+    assert msg == 'You breathed light into a whole new item. Its true name is vilmibm/lemongrab'
+
+    lemongrab = GameObject.get(GameObject.shortname=='vilmibm/lemongrab')
+
+    new_code = """
+    (witch "lemongrab"
+      (has {"name" "lemongrab"
+            "description" "a high strung lemon man"})
+      (hears "touch"
+        (says "UNACCEPTABLE")))""".rstrip().lstrip()
+
+    revision_payload = dict(
+        shortname='vilmibm/lemongrab',
+        code=new_code,
+        current_rev=lemongrab.script_revision.id)
+
+    await client.send('REVISION {}'.format(json.dumps(revision_payload)))
+    msg = await client.recv()
+    assert msg.startswith('OBJECT')
+
+    ### create an object for accepting whatever commands
+    await client.send('COMMAND create item "cat" it is a cat')
+    msg = await client.recv()
+    assert msg == 'COMMAND OK'
+    msg = await client.recv()
+    assert msg.startswith('STATE')
+    msg = await client.recv()
+    assert msg == 'You breathed light into a whole new item. Its true name is vilmibm/cat'
+
+    cat = GameObject.get(GameObject.shortname=='vilmibm/cat')
+
+    new_code = """
+    (witch "cat"
+      (has {"name" "cat"
+            "description" "it is a cat"})
+      (hears "touch"
+        (says "purr")))""".rstrip().lstrip()
+
+    revision_payload = dict(
+        shortname='vilmibm/cat',
+        code=new_code,
+        current_rev=cat.script_revision.id)
+
+    await client.send('REVISION {}'.format(json.dumps(revision_payload)))
+    msg = await client.recv()
+    assert msg.startswith('OBJECT')
+
+    # target found
+    await client.send('COMMAND touch lemongrab')
+    msg = await client.recv()
+    assert msg == 'COMMAND OK'
+    msg = await client.recv()
+    assert msg == 'lemongrab says, "UNACCEPTABLE"'
+
+    # TODO support for transitive-only commands
+
+    # target not found
+    await client.send('COMMAND touch contrivance')
+    msg = await client.recv()
+    assert msg == 'COMMAND OK'
+    msg = await client.recv()
+    assert msg == 'cat says, "purr"'
+    msg = await client.recv()
+    assert msg == 'lemongrab says, "UNACCEPTABLE"'
+
+    await client.close()

--- a/server/tmserver/tests/game_object_test.py
+++ b/server/tmserver/tests/game_object_test.py
@@ -135,51 +135,40 @@ class GameObjectDataTest(TildemushTestCase):
         assert 'brown' == self.snoozy.get_data('wrapper')
 
 
-def GameObjectComparisonTest(self):
-
+class GameObjectComparisonTest(TildemushTestCase):
     def setUp(self):
         super().setUp()
         self.vil = UserAccount.create(
             username='vilmibm',
             password='foobarbazquux')
-        self.snoozy = GameObject.create(
+        self.snoozy = GameObject.create_scripted_object(
             author=self.vil,
-            shortname='snoozy')
-
-        self.horse_script = Script.create(author=self.vil)
-        self.revision = ScriptRevision.create(code='<witch code>', script=self.horse_script)
+            shortname='snoozy',
+            format_dict=dict(
+                name='snoozy',
+                description='a horse'))
 
     def test_str_representation(self):
-        assert 'GameObject<snoozy> authored by {}'.format(self.vil) == str(self.snoozy)
-
-    def test_eq_operations_without_revisions(self):
-        snoozy = GameObject.get_by_id(self.snoozy.id)
-        assert True == (snoozy == self.snoozy)
-
-        snoozy.shortname = 'false-snoozy'
-        assert False == (snoozy == self.snoozy)
+        assert 'GameObject<snoozy>'.format(self.vil) == repr(self.snoozy)
+        assert 'snoozy'.format(self.vil) == str(self.snoozy)
 
     def test_eq_operations(self):
-        self.snoozy.script_revision = self.revision
-        self.snoozy.save()
         snoozy = GameObject.get_by_id(self.snoozy.id)
-        assert True == (snoozy == self.snoozy)
+        assert snoozy == self.snoozy
 
-        revision = ScriptRevision.create(code='(witch)', script=self.snoozy.script)
+        revision = ScriptRevision.create(code='(witch)', script=self.snoozy.script_revision.script)
         snoozy = GameObject.get_by_id(self.snoozy.id)
         snoozy.script_revision = revision
-        assert True == (snoozy != self.snoozy)
+        assert snoozy != self.snoozy
 
     def test_hash_operations(self):
-        self.snoozy.script_revision = self.revision
-        self.snoozy.save()
         snoozy = GameObject.get_by_id(self.snoozy.id)
-        assert True == (snoozy.__hash__() == self.snoozy.__hash__())
+        assert snoozy.__hash__() == self.snoozy.__hash__()
 
-        revision = ScriptRevision.create(code='(witch)', script=self.snoozy.script)
+        revision = ScriptRevision.create(code='(witch)', script=self.snoozy.script_revision.script)
         snoozy = GameObject.get_by_id(self.snoozy.id)
         snoozy.script_revision = revision
-        assert False == (snoozy.__hash__() == self.snoozy.__hash__())
+        assert snoozy.__hash__() != self.snoozy.__hash__()
 
 
 class GameObjectScriptEngineTest(TildemushTestCase):

--- a/server/tmserver/tests/logger_test.py
+++ b/server/tmserver/tests/logger_test.py
@@ -4,7 +4,7 @@ import unittest
 
 from ..logs import PGHandler, get_logger
 from ..models import Log
-from .tm_test_case import TildemushTestCase
+from .tm_test_case import TildemushTestCase, TildemushUnitTestCase
 
 
 class TestPGHandler(TildemushTestCase):
@@ -34,7 +34,7 @@ class TestPGHandler(TildemushTestCase):
         self.assertEqual(logs[0].raw, 'sweet')
 
 
-class TestLogging(TildemushTestCase):
+class TestLogging(TildemushUnitTestCase):
     def test_debug_ignores_pg(self):
         with mock.patch('logging.getLogger') as m:
             logger = get_logger(debug=True)

--- a/server/tmserver/tests/revision_test.py
+++ b/server/tmserver/tests/revision_test.py
@@ -5,9 +5,9 @@ from ..core import GameServer, UserSession
 from ..errors import ClientException, RevisionException
 from ..models import GameObject, UserAccount, ScriptRevision
 from ..world import GameWorld
-from .tm_test_case import TildemushTestCase
+from .tm_test_case import TildemushTestCase, TildemushUnitTestCase
 
-class GameServerRevisionHandlingTest(TildemushTestCase):
+class GameServerRevisionHandlingTest(TildemushUnitTestCase):
     def setUp(self):
         super().setUp()
         self.sess = Mock()
@@ -49,7 +49,7 @@ class GameServerRevisionHandlingTest(TildemushTestCase):
 
     # golden path test starting from core is in async_test
 
-class UserSessionRevisionHandlingTest(TildemushTestCase):
+class UserSessionRevisionHandlingTest(TildemushUnitTestCase):
     def test_revision_error(self):
         sess = UserSession(Mock(), GameWorld, Mock())
         sess.user_account = Mock()
@@ -62,7 +62,7 @@ class UserSessionRevisionHandlingTest(TildemushTestCase):
         assert payload == {'fun': 'times'}
         assert error == 'aw shit'
 
-    def test_chill(self):
+    def test_success(self):
         sess = UserSession(Mock(), GameWorld, Mock())
         sess.user_account = Mock()
         payload, error = (None, None)

--- a/server/tmserver/tests/tm_test_case.py
+++ b/server/tmserver/tests/tm_test_case.py
@@ -6,11 +6,14 @@ import pytest
 from ..migrations import reset_db
 from ..world import GameWorld
 
-
-class TildemushTestCase(unittest.TestCase):
+class TildemushUnitTestCase(unittest.TestCase):
     def setUp(self):
         if os.environ.get('TILDEMUSH_ENV') != 'test':
             pytest.exit('Run tildemush tests with TILDEMUSH_ENV=test')
+
+class TildemushTestCase(TildemushUnitTestCase):
+    def setUp(self):
+        super().setUp()
 
         reset_db()
         GameWorld.reset()

--- a/server/tmserver/util.py
+++ b/server/tmserver/util.py
@@ -1,7 +1,10 @@
 import re
 
-STRIP_COLOR_RE = re.compile(r'{[^}]+}')
+ARG_RE = re.compile(r'(\'[^\']+?\'|"[^"]+?"|[^"\' ]+)')
 COLLAPSE_WHITESPACE_RE = re.compile(r'\s+')
+QUOTED_RE = re.compile(r'^["\'](.*)["\']$')
+STRIP_COLOR_RE = re.compile(r'{[^}]+}')
+WHITESPACE_RE = re.compile(r'^\s*$')
 
 def strip_color_codes(string):
     """returns string with {color} {codes} {/} removed"""
@@ -9,4 +12,30 @@ def strip_color_codes(string):
 
 def collapse_whitespace(string):
     return COLLAPSE_WHITESPACE_RE.sub(' ', string).rstrip().lstrip()
+
+def is_whitespace(string):
+    return bool(WHITESPACE_RE.fullmatch(string))
+
+def clean_str(string):
+    """Given an argument found via split_args, this function:
+       - unquotes the string if needed
+       - collapses whitespace"""
+    out = None
+    match = QUOTED_RE.fullmatch(string)
+
+    if match:
+        out = match.groups()[0]
+    else:
+        out = string
+
+    return collapse_whitespace(out)
+
+def split_args(arg_str):
+    """Given a string like 'foo bar baz' or '"foo bar" baz quux', returns a
+    list of all the quote-delimited or space delimited strings."""
+    return [clean_str(s)
+            for s
+            in ARG_RE.split(arg_str)
+            if not (is_whitespace(s) or s in ('"', "'"))]
+
 

--- a/server/tmserver/world.py
+++ b/server/tmserver/world.py
@@ -5,7 +5,7 @@ from slugify import slugify
 from .config import get_db
 from .errors import RevisionException, WitchException, ClientException
 from .models import Contains, GameObject, Script, ScriptRevision, Permission, Editing
-from .util import strip_color_codes
+from .util import strip_color_codes, split_args
 
 OBJECT_DENIED = 'You grab a hold of {} but no matter how hard you pull it stays rooted in place.'
 OBJECT_NOT_FOUND = 'You look in vain for {}.'

--- a/server/tmserver/world.py
+++ b/server/tmserver/world.py
@@ -174,6 +174,17 @@ class GameWorld:
             o.handle_action(cls, sender_obj, action, action_args)
 
     @classmethod
+    def resolve_obj(cls, scope, search_str, ignore=[]):
+        """Given a list of GameObjects as scope, a search string, and an
+        optional list of GameObjects to ignore, searches for the first object
+        in scope for which .fuzzy_match(search_str) is True."""
+        for obj in scope:
+            if obj in ignore:
+                continue
+            if obj.fuzzy_match(search_str):
+                return obj
+
+    @classmethod
     def all_active_objects(cls):
         """This method assumes that if an object is contained by something
         else, it's "active" in the game; in other words, we're assuming that a


### PR DESCRIPTION
This PR:

- Adds a generally useful function for parsing a command's argument string (`util.split_args`)
- Adds a genereally useful function for fuzzily resolving objects in a given scope (`GameWorld.resolve_obj`)
- Adds a non-db-resetting test case superclass, `TildemushUnitTestCase`
- Implements support for targeted commands

Note that it's not yet possible in WITCH to create a transitive-only command; this PR just allows certain commands to be called on a single object but not *only* on a single object.