### PR TITLE
client tab refactor

### DIFF
--- a/client/tmclient/client.py
+++ b/client/tmclient/client.py
@@ -54,7 +54,7 @@ class Client:
         response = await self.connection.recv()
         if response == 'LOGIN OK':
             self.authenticated = True
-            self.ui.base = GameMain(self, self.loop, self.ui.loop)
+            self.ui.base = GameMain(self, self.loop, self.ui.loop, self.config)
         else:
             self.ui.base.message(response, 'error')
 

--- a/client/tmclient/config.py
+++ b/client/tmclient/config.py
@@ -35,8 +35,8 @@ class Config:
         self.path = new_path
         self.read()
 
-    def get(self, key):
-        return self._data.get(key)
+    def get(self, key, default=None):
+        return self._data.get(key, defaulT)
 
     def set(self, key, value):
         self._data[key] = value

--- a/client/tmclient/config.py
+++ b/client/tmclient/config.py
@@ -36,7 +36,7 @@ class Config:
         self.read()
 
     def get(self, key, default=None):
-        return self._data.get(key, defaulT)
+        return self._data.get(key, default)
 
     def set(self, key, value):
         self._data[key] = value

--- a/client/tmclient/screens.py
+++ b/client/tmclient/screens.py
@@ -124,10 +124,10 @@ class GameMain(urwid.Frame):
         self.scope = []
         self.hotkeys = self.load_hotkeys()
 
-        self.game_tab = ui.GameView(self.game_state)
-        self.witch_tab = ui.WitchView({}, self.scope)
-        self.worldmap_tab = ui.WorldmapView()
-        self.settings_tab = ui.SettingsView()
+        self.game_tab = ui.GameView(self.game_state, self.config)
+        self.witch_tab = ui.WitchView({}, self.scope, self.config)
+        self.worldmap_tab = ui.WorldmapView(self.config)
+        self.settings_tab = ui.SettingsView(self.config)
 
         # quit placeholder
         self.quit_prompt = urwid.Edit()

--- a/client/tmclient/screens.py
+++ b/client/tmclient/screens.py
@@ -174,8 +174,6 @@ class GameMain(urwid.Frame):
                     }
         self.scope = []
         self.hotkeys = self.load_hotkeys()
-        self.input_history = [""]
-        self.input_index = 0
 
         # game view stuff
         self.game_walker = urwid.SimpleFocusListWalker([

--- a/client/tmclient/screens.py
+++ b/client/tmclient/screens.py
@@ -125,18 +125,8 @@ class GameMain(urwid.Frame):
 
         self.game_tab = ui.GameView(self.game_state)
         self.witch_tab = ui.WitchView({})
-
-        # worldmap view stuff
-        self.worldmap_prompt = urwid.Edit()
-        self.worldmap_view = urwid.Filler(ColorText("worldmap coming soon", align='center'), valign='middle')
-        self.worldmap_tab = ui.GameTab(self.worldmap_view,
-                ui.TabHeader("F3 WORLDMAP"), self.worldmap_prompt)
-
-        # settings view stuff
-        self.settings_prompt = urwid.Edit()
-        self.settings_view = urwid.Filler(ColorText("settings menu under construction", align='center'), valign='middle')
-        self.settings_tab = ui.GameTab(self.settings_view,
-                ui.TabHeader("F4 SETTINGS"), self.settings_prompt)
+        self.worldmap_tab = ui.WorldmapView()
+        self.settings_tab = ui.SettingsView()
 
         # quit placeholder
         self.quit_prompt = urwid.Edit()

--- a/client/tmclient/screens.py
+++ b/client/tmclient/screens.py
@@ -347,6 +347,13 @@ class GameMain(urwid.Frame):
         elif key in self.hotkeys.get("rlwrap").keys() and isinstance(self.prompt, GamePrompt):
             self.prompt.handle_rlwrap(self.hotkeys.get("rlwrap").get(key))
 
+    def switch_tab(self, new_tab):
+        self.body.unfocus()
+        self.body = new_tab
+        self.body.focus()
+        self.focus_prompt()
+        self.refresh_tabs()
+
     def refresh_tabs(self):
         headers = []
         for tab in sorted(self.tabs.keys()):

--- a/client/tmclient/screens.py
+++ b/client/tmclient/screens.py
@@ -225,7 +225,7 @@ class GameMain(urwid.Frame):
         elif text.startswith('/'):
             text = text[1:]
         else:
-            chat_color = self.client_state.config.get('chat_color') or 'light magenta'
+            chat_color = self.config.get('chat_color', 'light magenta')
             if text:
                 text = 'say {'+chat_color+'}'+text+'{/}'
             else:
@@ -270,14 +270,16 @@ class GameMain(urwid.Frame):
 
     def update_state(self, raw_state):
         self.game_state = json.loads(raw_state)
+        self.update_scope()
+        self.game_tab.refresh(self.game_state)
+        self.witch_tab.refresh(self.game_state, self.scope)
+
+    def update_scope(self):
         self.scope.clear()
         for o in self.game_state.get("room").get("contains"):
             self.scope.append(o.get("shortname"))
         for o in self.game_state.get("inventory"):
             self.scope.append(o.get("shortname"))
-
-        self.game_tab.refresh(self.game_state)
-        self.witch_tab.refresh(self.game_state, self.scope)
 
     def load_hotkeys(self):
         defaults = {

--- a/client/tmclient/ui.py
+++ b/client/tmclient/ui.py
@@ -542,7 +542,7 @@ class ExternalEditor(urwid.Terminal):
 
         elif key in urwid.vterm.KEY_TRANSLATIONS:
             key = urwid.vterm.KEY_TRANSLATIONS[key]
-        
+
         elif key in KEY_ESCAPE_MAP:
             key = KEY_ESCAPE_MAP[key]
 

--- a/client/tmclient/ui.py
+++ b/client/tmclient/ui.py
@@ -333,6 +333,18 @@ class WitchView(GameTab):
         self.view.focus_position = 'body'
         super().__init__(self.view, TabHeader("F2 WITCH"), self.prompt)
 
+class WorldmapView(GameTab):
+    def __init__(self):
+        self.prompt = urwid.Edit()
+        self.view = urwid.Filler(ColorText("worldmap coming soon", align='center'), valign='middle')
+        super().__init__(self.view, TabHeader("F3 WORLDMAP"), self.prompt)
+
+class SettingsView(GameTab):
+    def __init__(self):
+        self.prompt = urwid.Edit()
+        self.view = urwid.Filler(ColorText("settings menu under construction", align='center'), valign='middle')
+        super().__init__(self.view, TabHeader("F4 SETTINGS"), self.prompt)
+
 class GameView(GameTab):
 
     def __init__(self, state):

--- a/client/tmclient/ui.py
+++ b/client/tmclient/ui.py
@@ -307,7 +307,10 @@ class ColorText(urwid.Text):
 
 class WitchView(GameTab):
 
-    def __init__(self, object_data):
+    def __init__(self, object_data, scope):
+        self.scope = scope
+        ## TODO: display items in scope when not editing anything
+
         self.info = {
                 "edit area": "NO OBJECT LOADED! /edit an object in the game view to work on it here",
                 "data": "Current Object: <None>",
@@ -332,6 +335,10 @@ class WitchView(GameTab):
         self.view = urwid.Frame(body=self.body, footer=self.status)
         self.view.focus_position = 'body'
         super().__init__(self.view, TabHeader("F2 WITCH"), self.prompt)
+
+    def refresh(self, data, new_scope):
+        self.scope = new_scope
+        ## TODO: update display of items in scope
 
 class WorldmapView(GameTab):
     def __init__(self):


### PR DESCRIPTION
this PR makes a pass on client ui/screens classes, cleaning up the code for tab handlers to make it easier to add new features and tweak existing ones.

changes:
* moves all game tab stuff (including gameprompt) into their own classes in ui.py
* adds a scope handler to the WITCH tab, which displays a list of object names in scope (okay i guess this is a little more than just a refactor but i was on a roll)
* preps for settings pane stuff by introducing user config (includes ability to customize mini panel layout in the game tab)