### PR TITLE
closes #125 by fixing reset color code

### DIFF
--- a/client/tmclient/ui.py
+++ b/client/tmclient/ui.py
@@ -40,8 +40,8 @@ palettes = [
     ('light cyan', 'light cyan', ''),
     ('white', 'white', ''),
     ('black', 'black', 'white'),
-    ('/', 'white', ''),
-    ('reset', 'white', '')]
+    ('/', 'default', ''),
+    ('reset', 'default', '')]
 
 KEY_ESCAPE_MAP = {
     key: urwid.vterm.ESC + sequence


### PR DESCRIPTION
this PR fixes the reset color code in the client, which will go beyond just correcting the `say` output; now all text that uses `/` or `reset` will return to the default terminal color, instead of white.