### PR TITLE
Sandbox spike

### DIFF
--- a/server/setup.py
+++ b/server/setup.py
@@ -26,6 +26,7 @@ setup(
         'bcrypt==3.1.4',
         'hy==0.15.0',
         'python-slugify==1.2.5',
+        'asteval==0.9.12',
     ],
     extras_require={
         'testing': [

--- a/server/tmserver/scripting.py
+++ b/server/tmserver/scripting.py
@@ -94,11 +94,15 @@ class WitchInterpreter:
             nonlocal receiver_model
             receiver_model._ensure_data(data)
 
+        def witch_open(*args, **kwargs):
+            raise NotImplementedError("No file access in WITCH")
+
         self.script_engine = script_engine
         self.interpreter = asteval.Interpreter(
             use_numpy=False,
             max_time=100000.0,  # there's a bug with this and setting it arbitrarily high avoids it
             usersyms=dict(
+                open=witch_open,
                 split_args=split_args,
                 add_handler=add_handler,
                 set_data=set_data,

--- a/server/tmserver/scripting.py
+++ b/server/tmserver/scripting.py
@@ -112,7 +112,7 @@ class WitchInterpreter:
     def evaluate_ast(self, witch_ast):
         self.interpreter(witch_ast)
         if self.interpreter.error_msg:
-            error_msg = aeval.error_msg
+            error_msg = self.interpreter.error_msg
             if 'in expr' in error_msg:
                 error_msg = ERROR_CLEANUP_RE.sub('', error_msg)
             raise WitchError(error_msg)
@@ -137,6 +137,8 @@ class ScriptEngine:
             self.game_world = game_world
 
     def _debug_handler(self, receiver, sender, action_args):
+        receiver = self.receiver_model.get_by_id(receiver.id)
+        sender = self.receiver_model.get_by_id(sender.id)
         return '{} <- {} with {}'.format(receiver, sender, action_args)
 
     def _contain_handler(self, receiver, sender, action_args):
@@ -153,6 +155,7 @@ class ScriptEngine:
 
     def _announce_handler(self, receiver, sender, action_args):
         receiver = self.receiver_model.get_by_id(receiver.id)
+        sender = self.receiver_model.get_by_id(sender.id)
         if receiver.user_account:
             msg = "The very air around you seems to shake as {}'s booming voice says {}".format(
                 sender.name, action_args)
@@ -160,12 +163,14 @@ class ScriptEngine:
 
     def _say_handler(self, receiver, sender, action_args):
         receiver = self.receiver_model.get_by_id(receiver.id)
+        sender = self.receiver_model.get_by_id(sender.id)
         if receiver.user_account:
             msg = '{} says, \"{}\"'.format(sender.name, action_args)
             self.game_world.user_hears(receiver, sender, msg)
 
     def _whisper_handler(self, receiver, sender, action_args):
         receiver = self.receiver_model.get_by_id(receiver.id)
+        sender = self.receiver_model.get_by_id(sender.id)
         if receiver.user_account:
             msg = '{} whispers so only you can hear: {}'.format(sender.name, action_args)
             self.game_world.user_hears(receiver, sender, msg)

--- a/server/tmserver/scripting.py
+++ b/server/tmserver/scripting.py
@@ -195,9 +195,6 @@ class ScriptedObjectMixin:
     def teleport_sender(self, sender_obj, target_room_name):
         self.game_world.move_obj(sender_obj, target_room_name)
 
-    def get_split_args(self, action_args):
-        return split_args(action_args)
-
     def _execute_script(self, witch_code):
         """Given a pile of script revision code, this function prepends the
         (witch) macro definition and then reads and evals the combined code."""
@@ -210,6 +207,7 @@ class ScriptedObjectMixin:
             use_numpy=False,
             max_time=1000000.0,
             usersyms={
+                'split_args': split_args,
                 'ScriptEngine': ScriptEngine,
                 'ensure_obj_data': lambda data: self._ensure_data(data)})
         while not stop:

--- a/server/tmserver/tests/evil_witch_test.py
+++ b/server/tmserver/tests/evil_witch_test.py
@@ -37,3 +37,19 @@ class EvilWitchTest(TildemushTestCase):
         with self.assertRaisesRegex(NotImplementedError, 'ImportFrom') as cm:
             game_obj.init_scripting()
             game_obj.engine.handlers['lol'](MagicMock(), MagicMock(), MagicMock())
+
+    # TODO
+    # For this, I wonder if the solution is not passing an instance of a Model
+    # but a proxy object without the model functions?
+    def test_prevents_db_access_via_model(self):
+        code = """
+        (witch "foo"
+           (has {"foo" "bar"})
+           (hears "lol"
+              (for [ua (receiver.author.select)]
+                (says ua.username))))"""
+        game_obj = self.create_obj_with_code(code)
+
+        with self.assertRaisesRegex(NotImplementedError, 'ImportFrom') as cm:
+            game_obj.init_scripting()
+            game_obj.engine.handlers['lol'](MagicMock(), MagicMock(), MagicMock())

--- a/server/tmserver/tests/evil_witch_test.py
+++ b/server/tmserver/tests/evil_witch_test.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock
 from ..errors import WitchError
 from ..models import GameObject, Script, ScriptRevision, UserAccount, Permission
+from ..world import GameWorld
 from .tm_test_case import TildemushTestCase
 
 class EvilWitchTest(TildemushTestCase):
@@ -36,7 +37,7 @@ class EvilWitchTest(TildemushTestCase):
 
         with self.assertRaisesRegex(NotImplementedError, 'ImportFrom') as cm:
             game_obj.init_scripting()
-            game_obj.engine.handlers['lol'](MagicMock(), MagicMock(), MagicMock())
+            game_obj.handle_action(GameWorld, game_obj, 'lol', '')
 
     # TODO
     # For this, I wonder if the solution is not passing an instance of a Model
@@ -50,6 +51,15 @@ class EvilWitchTest(TildemushTestCase):
                 (says ua.username))))"""
         game_obj = self.create_obj_with_code(code)
 
-        with self.assertRaisesRegex(NotImplementedError, 'ImportFrom') as cm:
+        with self.assertRaisesRegex(AttributeError, 'author') as cm:
             game_obj.init_scripting()
-            game_obj.engine.handlers['lol'](MagicMock(), MagicMock(), MagicMock())
+            game_obj.handle_action(GameWorld, game_obj, 'lol', '')
+
+
+    def test_prevents_malicious_introspection(self):
+        # TODO
+        pass
+
+    def test_prevents_opening_files(self):
+        # TODO
+        pass

--- a/server/tmserver/tests/evil_witch_test.py
+++ b/server/tmserver/tests/evil_witch_test.py
@@ -24,7 +24,6 @@ class EvilWitchTest(TildemushTestCase):
             shortname='something nasty',
             script_revision=scriptrev)
 
-
     def test_prevents_import(self):
         code = """
         (witch "foo"
@@ -39,9 +38,6 @@ class EvilWitchTest(TildemushTestCase):
             game_obj.init_scripting()
             game_obj.handle_action(GameWorld, game_obj, 'lol', '')
 
-    # TODO
-    # For this, I wonder if the solution is not passing an instance of a Model
-    # but a proxy object without the model functions?
     def test_prevents_db_access_via_model(self):
         code = """
         (witch "foo"
@@ -57,9 +53,27 @@ class EvilWitchTest(TildemushTestCase):
 
 
     def test_prevents_malicious_introspection(self):
-        # TODO
-        pass
+        code = """
+        (witch "foo"
+          (has {"foo" "bar"})
+          (hears "lol"
+            ((get (.__subclasses__ (get print.__class__.__bases__ 0)) 323) "bash")))
+        """
+        game_obj = self.create_obj_with_code(code)
+
+        with self.assertRaisesRegex(AttributeError, '__class__') as cm:
+            game_obj.init_scripting()
+            game_obj.handle_action(GameWorld, game_obj, 'lol', '')
 
     def test_prevents_opening_files(self):
-        # TODO
-        pass
+        code = """
+        (witch "foo"
+          (has {"foo" "bar"})
+          (hears "lol"
+            (says (.readlines (open "/tmp/foo")))))
+        """
+        game_obj = self.create_obj_with_code(code)
+
+        with self.assertRaisesRegex(NotImplementedError, 'witch_open') as cm:
+            game_obj.init_scripting()
+            game_obj.handle_action(GameWorld, game_obj, 'lol', '')

--- a/server/tmserver/tests/evil_witch_test.py
+++ b/server/tmserver/tests/evil_witch_test.py
@@ -1,0 +1,39 @@
+from unittest.mock import MagicMock
+from ..errors import WitchError
+from ..models import GameObject, Script, ScriptRevision, UserAccount, Permission
+from .tm_test_case import TildemushTestCase
+
+class EvilWitchTest(TildemushTestCase):
+    def setUp(self):
+        super().setUp()
+        self.ua = UserAccount.create(
+            username='vilmibm',
+            password='foobarbazquux')
+
+    def create_obj_with_code(self, code):
+        script = Script.create(
+            author=self.ua,
+            name='something nasty')
+        scriptrev = ScriptRevision.create(
+            script=script,
+            code=code)
+        return GameObject.create(
+            perms=Permission(),
+            author=self.ua,
+            shortname='something nasty',
+            script_revision=scriptrev)
+
+
+    def test_prevents_import(self):
+        code = """
+        (witch "foo"
+           (has {"foo" "bar"})
+           (hears "lol"
+              (import [tmserver.models [UserAccount]])
+              (for [ua (.select UserAccount)]
+                (says ua.username))))"""
+        game_obj = self.create_obj_with_code(code)
+
+        with self.assertRaisesRegex(NotImplementedError, 'ImportFrom') as cm:
+            game_obj.init_scripting()
+            game_obj.engine.handlers['lol'](MagicMock(), MagicMock(), MagicMock())

--- a/server/tmserver/tests/game_object_test.py
+++ b/server/tmserver/tests/game_object_test.py
@@ -201,7 +201,7 @@ class GameObjectScriptEngineTest(TildemushTestCase):
             script_revision=self.script_rev)
 
     def test_no_script_revision(self):
-        result = self.vil.handle_action(GameWorld, self.snoozy, 'kick', [])
+        result = self.vil.handle_action(GameWorld, self.snoozy, 'kick', '')
         assert result is None
 
     def test_engine_is_created(self):
@@ -219,17 +219,17 @@ class GameObjectScriptEngineTest(TildemushTestCase):
             mock_say.assert_called_once_with('neigh neigh neigh i am horse')
 
     def test_debug_handler(self):
-        result = self.snoozy.handle_action(GameWorld, self.vil, 'debug', [])
-        assert result == '{} <- {} with []'.format(self.snoozy, self.vil)
+        result = self.snoozy.handle_action(GameWorld, self.vil, 'debug', 'foobar')
+        assert result == '{} <- {} with foobar'.format(self.snoozy, self.vil)
 
     def test_bad_witch(self):
         self.script_rev.code = '''(witch)'''
         self.script_rev.save()
         with self.assertRaises(WitchError):
-            self.snoozy.handle_action(GameWorld, self.vil, 'pet', [])
+            self.snoozy.handle_action(GameWorld, self.vil, 'pet', '')
 
     def test_unhandled_action(self):
-        assert None == self.snoozy.handle_action(GameWorld, 'poke', self.vil, [])
+        assert None == self.snoozy.handle_action(GameWorld, self.vil, 'poke', '')
         with mock.patch('tmserver.scripting.ScriptEngine.noop') as mock_noop:
-            self.snoozy.handle_action(GameWorld, 'poke', self.vil, [])
+            self.snoozy.handle_action(GameWorld, self.vil, 'poke', [])
             assert mock_noop.called

--- a/server/tmserver/tests/game_object_test.py
+++ b/server/tmserver/tests/game_object_test.py
@@ -1,4 +1,3 @@
-import types
 from unittest import mock
 from .. import models
 from ..errors import WitchError
@@ -208,9 +207,6 @@ class GameObjectScriptEngineTest(TildemushTestCase):
     def test_engine_is_created(self):
         eng = self.snoozy.engine
         assert isinstance(eng, ScriptEngine)
-
-    def test_handler_added(self):
-        assert type(self.snoozy.engine.handler(GameWorld, 'pet')) == types.FunctionType
 
     def test_handler_works(self):
         self.snoozy.handle_action(GameWorld, self.vil, 'pet', '')

--- a/server/tmserver/tests/mode_test.py
+++ b/server/tmserver/tests/mode_test.py
@@ -19,14 +19,14 @@ class TestModeCommand(TildemushUnitTestCase):
     def test_not_found(self):
         with self.assertRaisesRegex(UserError, 'You look in vain for'):
             with mock.patch('tmserver.GameWorld.resolve_obj', return_value=None):
-                GameWorld.handle_mode(None, 'foo bar baz')
+                GameWorld.handle_mode(mock.MagicMock(), 'foo bar baz')
 
     def test_bad_perm(self):
         with self.assertRaisesRegex(UserError, 'invalid permission'):
             with mock.patch('tmserver.GameWorld.resolve_obj', return_value='fake'):
-                GameWorld.handle_mode(None, 'foo bar baz')
+                GameWorld.handle_mode(mock.MagicMock(), 'foo bar baz')
 
     def test_bad_value(self):
         with self.assertRaisesRegex(UserError, 'invalid value'):
             with mock.patch('tmserver.GameWorld.resolve_obj', return_value='fake'):
-                GameWorld.handle_mode(None, 'foo carry baz')
+                GameWorld.handle_mode(mock.MagicMock(), 'foo carry baz')

--- a/server/tmserver/witch_header.hy
+++ b/server/tmserver/witch_header.hy
@@ -19,7 +19,7 @@
                      ~se
                      ~(get hp 1)
                      (fn [receiver sender arg]
-                       (setv args (.get-split-args receiver arg))
+                       (setv args (split-args arg))
                        (setv from-me? (= receiver sender))
                        ~@(cut hp 2))) )
          actions)

--- a/server/tmserver/witch_header.hy
+++ b/server/tmserver/witch_header.hy
@@ -1,7 +1,7 @@
 #_("TODO support additional args, here. right now, they have to be one big string.")
 (defmacro tell-sender [action args] `(witch-tell-sender sender ~action ~args))
 (defmacro move-sender [direction] `(witch-move-sender sender ~direction))
-(defmacro teleport-sender [target_room_name] `(witch_teleport-sender sender ~target_room_name))
+(defmacro teleport-sender [target-room-name] `(witch-teleport-sender sender ~target-room-name))
 
 #_("TODO eventually decide on cmd-args handling")
 

--- a/server/tmserver/witch_header.hy
+++ b/server/tmserver/witch_header.hy
@@ -1,32 +1,23 @@
-(defmacro set-data [key value] `(.set-data receiver ~key ~value))
-(defmacro get-data [key] `(.get-data receiver ~key))
-(defmacro says [message] `(.say receiver ~message))
 #_("TODO support additional args, here. right now, they have to be one big string.")
-(defmacro tell-sender [action args] `(.tell-sender receiver sender ~action ~args))
-(defmacro move-sender [direction] `(.move-sender receiver sender ~direction))
-(defmacro teleport-sender [target_room_name] `(.teleport-sender receiver sender ~target_room_name))
+(defmacro tell-sender [action args] `(witch-tell-sender sender ~action ~args))
+(defmacro move-sender [direction] `(witch-move-sender sender ~direction))
+(defmacro teleport-sender [target_room_name] `(witch_teleport-sender sender ~target_room_name))
 
 #_("TODO eventually decide on cmd-args handling")
 
 (defmacro witch
   [script_name data &rest actions]
-  (setv se (gensym))
   (setv hp (gensym))
   `(do
-     (setv ~se (ScriptEngine))
      ~@(map
-         (fn [hp] `(.add-handler
-                     ~se
+         (fn [hp] `(add-handler
                      ~(get hp 1)
                      (fn [receiver sender arg]
                        (setv args (split-args arg))
                        (setv from-me? (= receiver sender))
                        ~@(cut hp 2))) )
          actions)
-     (ensure-obj-data ~(get data 1))
-     ~se
-     ~se))
-
+     (ensure-obj-data ~(get data 1))))
 
 
 #_(setv hmm (witch "horse"

--- a/server/tmserver/witch_header.hy
+++ b/server/tmserver/witch_header.hy
@@ -24,6 +24,7 @@
                        ~@(cut hp 2))) )
          actions)
      (ensure-obj-data ~(get data 1))
+     ~se
      ~se))
 
 


### PR DESCRIPTION
this PR covers using `asteval` to run compiled Hy code. It prevents module import and leaky object introspection. This PR also fixes up the main `witch` macro so it hides references to DB models and ScriptEngines.