### PR TITLE
reimplement transitive commands to support $this

### DIFF
--- a/server/tmserver/util.py
+++ b/server/tmserver/util.py
@@ -1,6 +1,7 @@
 import re
 
-ARG_RE = re.compile(r'(\'[^\']+?\'|"[^"]+?"|[^"\' ]+)')
+ARG_RE_RAW = '(\'[^\']+?\'|"[^"]+?"|[^"\' ]+)'
+ARG_RE = re.compile(ARG_RE_RAW)
 COLLAPSE_WHITESPACE_RE = re.compile(r'\s+')
 QUOTED_RE = re.compile(r'^["\'](.*)["\']$')
 STRIP_COLOR_RE = re.compile(r'{[^}]+}')
@@ -37,5 +38,3 @@ def split_args(arg_str):
             for s
             in ARG_RE.split(arg_str)
             if not (is_whitespace(s) or s in ('"', "'"))]
-
-

--- a/server/tmserver/world.py
+++ b/server/tmserver/world.py
@@ -184,20 +184,10 @@ class GameWorld:
             # cased in this if/else chain. we have this artificial check just
             # to avoid falling into the transitive branch. i hate it.
             pass
-        else:
-            # it's not a pre-defined action. we now want to see if it's
-            # targeted at some object.
-            args = split_args(action_args)
-            if len(args) > 0:
-                target_search_str = args[0]
-                target = cls.resolve_obj(cls.area_of_effect(sender_obj), target_search_str)
-                without_target = ARG_RE.sub('', action_args, count=1).rstrip().lstrip()
-                if target:
-                    target.handle_action(cls, sender_obj, action, without_target)
-                    return
 
         # if we make it here it means we've encountered a command that objects
-        # in the area should all "hear"
+        # in the area should have a chance to respond. If we hit a transitive
+        # command, halt will be True and we'll stop parsing.
         aoe = cls.area_of_effect(sender_obj)
         for o in aoe:
             o.handle_action(cls, sender_obj, action, action_args)


### PR DESCRIPTION
this PR:

- pushes transitive command handling into ScriptEngine`
- allows targeting commands based on `$this` anywhere in the command string
- adds async and unit tests for the targeting