### PR TITLE
Improve state send

### DIFF
--- a/server/tmserver/tests/contain_test.py
+++ b/server/tmserver/tests/contain_test.py
@@ -30,7 +30,6 @@ class ContainTest(TildemushTestCase):
         assert player_obj in self.room.contains
         assert self.phone in player_obj.contains
         assert self.app in self.phone.contains
-        import ipdb; ipdb.set_trace()
         bust_ghosts()
         assert player_obj not in self.room.contains
         assert self.phone in player_obj.contains

--- a/server/tmserver/world.py
+++ b/server/tmserver/world.py
@@ -162,13 +162,6 @@ class GameWorld:
             cls.handle_create(sender_obj, action_args)
         elif action == 'edit':
             cls.handle_edit(sender_obj, action_args)
-            aoe = cls.area_of_effect(sender_obj)
-            for o in aoe:
-                if o.is_player_obj:
-                    cls.send_client_update(o.user_account)
-            # TODO this doesn't seem to result in the updated data being sent in
-            # client state, but my reading of that method is that it would send
-            # fresh db data
             return
         elif action == 'mode':
             cls.handle_mode(sender_obj, action_args)
@@ -891,6 +884,12 @@ class GameWorld:
 
             result = cls.object_state(obj)
             result['errors'] = witch_errors
+
+        if not result['errors']:
+            aoe = cls.area_of_effect(owner_obj)
+            for o in aoe:
+                if o.is_player_obj:
+                    cls.send_client_update(o.user_account)
 
         return result
 


### PR DESCRIPTION
ugh async test is getting even unwieldier with more STATEs (not to mentioned existing COMMAND OKs). I'm thinking seriously about filtering those out in tests by default then having a few test cases that just make sure STATE is sent when appropriate.