### PR TITLE
show map in client

### DIFF
--- a/client/tmclient/screens.py
+++ b/client/tmclient/screens.py
@@ -259,6 +259,9 @@ class GameMain(urwid.Frame):
         self.body.focus()
         self.focus_prompt()
         self.refresh_tabs()
+        # TODO this is obviously very bad style but I'm at a loss:
+        if new_tab == self.worldmap_tab:
+            asyncio.ensure_future(self.client_state.send('MAP'), loop=self.loop)
 
     def refresh_tabs(self):
         headers = []

--- a/client/tmclient/ui.py
+++ b/client/tmclient/ui.py
@@ -363,13 +363,14 @@ class WorldmapView(GameTab):
         self.prompt = urwid.Edit()
         self.config = config
         # TODO be able to render scrollable text; what urwid thing to use?
-        self.view = urwid.Filler(ColorText("worldmap coming soon", align='center'), valign='middle')
+        self.rendered_map = 'something should show here...'
+        self.view = urwid.Filler(ColorText(self.rendered_map, align='center'), valign='middle')
         super().__init__(self.view, TabHeader("F3 WORLDMAP"), self.prompt)
 
     def update_map(self, rendered_map):
         self.rendered_map = rendered_map
-        self.view = urwid.Filler(ColorText("{green}{}".format(self.rendered_map)))
-        # TODO tell view to re-render
+        self.view.original_widget = ColorText(self.rendered_map, align='center')
+
 
 class SettingsView(GameTab):
     def __init__(self, config):

--- a/server/tmserver/core.py
+++ b/server/tmserver/core.py
@@ -85,7 +85,7 @@ class UserSession:
         return return_payload, revision_exception
 
     def handle_map(self):
-        return self.game_world.render_map(self.user_account.player_obj)
+        return self.game_world.handle_map(self.user_account.player_obj)
 
     def handle_disconnect(self):
         if not self.associated:


### PR DESCRIPTION
Fixes #177 

This works!

There is *NO CACHING* or any optimizations at all for this and it will be one of the first things to hurt tush's performance i think, but we'll cross that bridge when we come to it.

@modgethanc can you think of a better way to do "take arbitrary action when tab is shown"? i don't like what i did (sniffing for map tab and doing something conditionally), but when i put a call back on the map tab realized i didn't have access to the async client...