### PR TITLE
fix needing initial manual /look

### DIFF
--- a/client/tmclient/client.py
+++ b/client/tmclient/client.py
@@ -55,8 +55,13 @@ class Client:
         if response == 'LOGIN OK':
             self.authenticated = True
             self.ui.base = GameMain(self, self.loop, self.ui.loop, self.config)
+            await self.start_listen_loop()
+            await self.refresh()
         else:
             self.ui.base.message(response, 'error')
+
+    async def refresh(self):
+        await self.connection.send('REFRESH')
 
     async def register(self, username, password):
         await self.connection.send('REGISTER {}:{}'.format(username, password))

--- a/server/tmserver/core.py
+++ b/server/tmserver/core.py
@@ -166,6 +166,8 @@ class GameServer:
                     # in that it tells the client "yes, i saw you; if you don't
                     # get a response it's not because i didn't see you."
                     await user_session.client_send('COMMAND OK')
+            elif message.startswith('REFRESH'):
+                self.handle_refresh(user_session)
             elif message.startswith('REVISION'):
                 revision_result, revision_exception = self.handle_revision(user_session, message)
                 if revision_exception:
@@ -203,6 +205,11 @@ class GameServer:
         if match is None:
             raise ClientError('malformed command message: {}'.format(message))
         return match.groups()
+
+    def handle_refresh(self, user_session):
+        if not user_session.associated:
+            raise ClientError('can only refresh if logged in')
+        user_session.handle_client_update(self.game_world.client_state(user_session.user_account))
 
     def handle_login(self, user_session, message):
         if user_session.associated:

--- a/server/tmserver/world.py
+++ b/server/tmserver/world.py
@@ -33,7 +33,6 @@ class GameWorld:
         if user_account.id in cls._sessions:
             raise ClientError('User {} already logged in.'.format(user_account))
 
-
         cls._sessions[user_account.id] = user_session
 
         player_obj = user_account.player_obj


### PR DESCRIPTION
we were lazily starting up a listen loop after a user's first attempt at input; this PR unlazily starts the loop after a successful login and issues a new `REFRESH` command that triggers a send of client state.