### PR TITLE
chmod 600 user config file, hash client side password on registration…

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ This instance is volatile (ie it's liable to go down or have its database wiped 
 [https://wiki.archlinux.org/index.php/PostgreSQL](https://wiki.archlinux.org/index.php/PostgreSQL)
 
 * `sudo su postgres`
-* `initdb --locale $LANG -E UTF8 -D '/var/lib/postgres/data'`
+* `initdb --locale $LANG -E UTF8 -D '/var/lib/postgres/data'` - note: if that fails you may need to give the postgres user a password with `sudo passwd postgres`
 * `sudo systemctl enable postgresql` - configure postgres service to start on boot
 * `sudo systemctl start postgresql.service` - start postgres service
 * `createuser tildemush -W` (will prompt for password, use `tildemush`)

--- a/client/tmclient/client.py
+++ b/client/tmclient/client.py
@@ -65,8 +65,6 @@ class Client:
         await self.connection.send('REFRESH')
 
     async def register(self, username, password):
-        # hash on client side to avoid plaintext passwords
-        password = bcrypt.hashpw(password.encode('utf-8'), bcrypt.gensalt()).decode('utf-8')
         await self.connection.send('REGISTER {}:{}'.format(username, password))
         response = await self.connection.recv()
         if response == 'REGISTER OK':

--- a/client/tmclient/client.py
+++ b/client/tmclient/client.py
@@ -3,6 +3,7 @@ import asyncio
 import json
 import websockets
 import urwid
+import bcrypt
 
 from .config import Config
 from . import ui
@@ -64,6 +65,8 @@ class Client:
         await self.connection.send('REFRESH')
 
     async def register(self, username, password):
+        # hash on client side to avoid plaintext passwords
+        password = bcrypt.hashpw(password.encode('utf-8'), bcrypt.gensalt()).decode('utf-8')
         await self.connection.send('REGISTER {}:{}'.format(username, password))
         response = await self.connection.recv()
         if response == 'REGISTER OK':

--- a/client/tmclient/config.py
+++ b/client/tmclient/config.py
@@ -18,6 +18,7 @@ class Config:
     def __init__(self, path=DEFAULT_CONFIG_PATH):
         self.path = path
         ensure_config_file(path)
+        os.chmod(path, 0o600)
         self._data = CONFIG_DEFAULTS
         self.read()
 

--- a/resetDB
+++ b/resetDB
@@ -1,0 +1,5 @@
+#!./venv/bin/python
+
+import server.tmserver.migrations
+server.tmserver.migrations.reset_db()
+print("db reset!")


### PR DESCRIPTION
… (probably a bad idea)

The thing here is:

* user files are generally considered secure with the right permissions
* hashing user password on client with a salt means it's only recoverable from the config file, the user entered password wouldn't grant access to the account