### PR TITLE
Don't use --process-dependency-links for client setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This instance is volatile (ie it's liable to go down or have its database wiped 
 * `python -m virtualenv venv` - create a virtualenv in the project directory
 * `source venv/bin/activate`
 * `cd server && pip install -e ".[testing]" && cd ..`
-* `cd client && pip install --process-dependency-links -e ".[testing]" && cd ..`
+* `cd client && pip install -e ".[testing]" && cd ..`
 * setup `postgres` (see below)
 
 ### postgres setup (Arch linux)

--- a/client/setup.py
+++ b/client/setup.py
@@ -19,10 +19,9 @@ setup(
     # TODO we use a forked urwid that patches a bug which causes errors to be swallowed
     #      when using asyncio+urwid. Hopefully we can switch back to the main urwid before 
     #      too long.
-    dependency_links=['git+https://github.com/tildetown/urwid.git#egg=urwid-3.0.0'],
     install_requires=[
         'click==6.7',
-        'urwid==3.0.0',
+        'urwid @ https://api.github.com/repos/tildetown/urwid/tarball',
         'websockets==6.0.0',
     ],
     extras_require={


### PR DESCRIPTION
The `--process-dependency-links` option was removed [in pip v19](https://pip.pypa.io/en/stable/news/#id19). So, let's grab the tarball directly using the GitHub API so we can continue to use new versions of pip.